### PR TITLE
systemd: Use absolute paths in Exec

### DIFF
--- a/playbooks/templates/standalone_public_route.service.j2
+++ b/playbooks/templates/standalone_public_route.service.j2
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=exec
-ExecStart=ip route replace {{ cidr }} dev {{ interface_name }} scope link
+ExecStart=/usr/sbin/ip route replace {{ cidr }} dev {{ interface_name }} scope link
 RemainAfterExit=true
 StandardOutput=journal
 Restart=on-failure

--- a/playbooks/templates/standalone_public_snat.service.j2
+++ b/playbooks/templates/standalone_public_snat.service.j2
@@ -4,7 +4,7 @@ After=network-online.target
 
 [Service]
 Type=oneshot
-ExecStart=iptables -t nat -A POSTROUTING -s {{ cidr }} -o {{ exit_if }} -j SNAT --to {{ exit_ip }}
+ExecStart=/usr/sbin/iptables -t nat -A POSTROUTING -s {{ cidr }} -o {{ exit_if }} -j SNAT --to {{ exit_ip }}
 RemainAfterExit=true
 StandardOutput=journal
 


### PR DESCRIPTION
When executing the units, systemd errors with:

```
[/etc/systemd/system/standalone_public_route.service:7] Executable path is not absolute, ignoring: ip route replace [...]
```

With this change, `ip` and `iptables` are called using their expected
absolute path.