### PR TITLE
Create the scripts directory if it does not exist

### DIFF
--- a/playbooks/local_os_client.yaml
+++ b/playbooks/local_os_client.yaml
@@ -67,6 +67,12 @@
       name: python-openstackclient
       extra_args: --user
 
+  - name: Create the scripts if it does not exist
+    ansible.builtin.file:
+      path: ../scripts
+      state: directory
+      mode: '0755'
+
   - name: Write sshuttle script
     template:
       src: sshuttle-standalone.sh.j2


### PR DESCRIPTION
Otherwise the playbook blows up.