### PR TITLE
Set default cloudname

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ inventory.yaml:
 	echo -e "all:\n  hosts:\n    standalone:\n      ansible_host: $(host)\n      ansible_user: root\n" > $@
 
 local-overrides.yaml:
-	echo -e "# Override default variables by putting them in this file\ncloudname: standalone\nstandalone_host: $(host)" > $@
+	echo -e "# Override default variables by putting them in this file\nstandalone_host: $(host)" > $@
 
 
 #

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This will configure your local clouds.yaml with 2 entries:
 * `standalone` - The admin user
 * `standalone_openshift` - The appropriately configured non-admin openshift user
 
-You can change the name of these entries by editing `local-overrides.yaml` and setting `cloudname` to something else.
+You can change the name of these entries by editing `local-overrides.yaml` and
+setting `local_cloudname` to something else.
 
 ## Network configuration
 

--- a/playbooks/local_os_client.yaml
+++ b/playbooks/local_os_client.yaml
@@ -43,16 +43,16 @@
         set_fact:
           cloudsyaml: "{{ {'clouds': {}} }}"
 
-  - name: Merge standalone from remote clouds.yaml into local clouds.yaml entry {{ cloudname }}
+  - name: Merge standalone from remote clouds.yaml into local clouds.yaml entry {{ local_cloudname }}
     set_fact:
-      cloudsyaml: "{{ cloudsyaml | combine({'clouds': {cloudname: standalone}}, recursive=true) }}"
+      cloudsyaml: "{{ cloudsyaml | combine({'clouds': {local_cloudname: standalone}}, recursive=true) }}"
     vars:
       standalone: "{{ hostvars['standalone']['cloudsyaml']['clouds']['standalone'] }}"
     when: "'standalone' in hostvars['standalone']['cloudsyaml']['clouds']"
 
-  - name: Merge openshift from remote clouds.yaml into local clouds.yaml entry {{ cloudname }}_openshift
+  - name: Merge openshift from remote clouds.yaml into local clouds.yaml entry {{ local_cloudname }}_openshift
     set_fact:
-      cloudsyaml: "{{ cloudsyaml | combine({'clouds': {cloudname + '_openshift': openshift}}, recursive=true) }}"
+      cloudsyaml: "{{ cloudsyaml | combine({'clouds': {local_cloudname + '_openshift': openshift}}, recursive=true) }}"
     vars:
       openshift: "{{ hostvars['standalone']['cloudsyaml']['clouds']['openshift'] }}"
     when: "'openshift' in hostvars['standalone']['cloudsyaml']['clouds']"
@@ -82,7 +82,7 @@
   - debug:
       msg:
       - "{{ cloudsyamlpath }} has been updated."
-      - "To connect to your cloud set OS_CLOUD={{ cloudname }} and update your local routes."
+      - "To connect to your cloud set OS_CLOUD={{ local_cloudname }} and update your local routes."
       - "For convenience:"
       - "  `scripts/sshuttle-standalone.sh` will start a correctly configure sshuttle."
       - "  `source scripts/env.sh` will set OS_CLOUD correctly."

--- a/playbooks/templates/env.sh.j2
+++ b/playbooks/templates/env.sh.j2
@@ -1,1 +1,1 @@
-export OS_CLOUD={{ cloudname }}
+export OS_CLOUD={{ local_cloudname }}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -3,6 +3,10 @@ rhos_release: 17
 hostname: standalone
 clouddomain: shiftstack
 
+# The name of the cloud in *local* clouds.yaml. On the host it will always be
+# called `standalone`.
+local_cloudname: standalone
+
 control_plane_ip: 192.168.24.1
 
 # The public network is used for all user traffic. It is used for:


### PR DESCRIPTION
The variable was previously never set. This now sets it to `standalone`
unless it is set somewhere else.