### PR TITLE
Enable Octavia

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -22,3 +22,8 @@ parameter_defaults:
   InterfaceLocalMtu: 1500
   SELinuxMode: permissive
   StandaloneNetworkConfigTemplate: "{{ ansible_env.HOME }}/dev-install_net_config.yaml"
+  # These 2 Octavia parameters are required to be set even if we don't use the Amphora thanks
+  # to the OVN provider in Octavia.
+  OctaviaGenerateCerts: true
+  OctaviaCaKeyPassphrase: "secrete"
+  OctaviaAmphoraSshKeyFile: "{{ ansible_env.HOME }}/octavia.pub"

--- a/playbooks/templates/tripleo-deploy.sh.j2
+++ b/playbooks/templates/tripleo-deploy.sh.j2
@@ -1,10 +1,14 @@
 #!/bin/sh
 
+# Generate a keypair for Octavia Amphora (needed by TripleO)
+ssh-keygen -b 2048 -t rsa -f {{ stack_home }}/octavia -q -N ""
+
 sudo openstack tripleo deploy \
     --templates \
     --local-ip={{ control_plane_ip }} \
     --control-virtual-ip {{ public_api }} \
     -e /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml \
+    -e /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml \
     -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
     -e {{ stack_home }}/containers-prepare-parameters.yaml \
     -e {{ stack_home }}/standalone_parameters.yaml \


### PR DESCRIPTION
Enable Octavia (Load Balancer as a Service in OpenStack) by default,
since it's used when enabling Kuryr instead of OpenShiftSDN.

Note that we have to specify both OctaviaGenerateCerts and
OctaviaCaKeyPassphrase, to make the deployment happy but since we don't
use the Amphora driver (we use OVN-provider), it doesn't matter that the
passphrase is not secured.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
