### PR TITLE
flavor: increase storage for m1.large

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -64,7 +64,7 @@
           openstack flavor create --ram 4096 --disk 20 --vcpu 2 --public m1.medium
       fi
       if ! openstack flavor show m1.large; then
-          openstack flavor create --ram 8192 --disk 20 --vcpu 4 --public m1.large
+          openstack flavor create --ram 8192 --disk 25 --vcpu 4 --public m1.large
       fi
       if ! openstack flavor show m1.xlarge; then
           openstack flavor create --ram 16384 --disk 40 --vcpu 4 --public m1.xlarge


### PR DESCRIPTION
In shiftstack-ci, we use m1.large name for flavors of workers, so let's
use 25GB of disk as it's a minimum.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
