### PR TITLE
octavia: download amphora images

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -20,6 +20,13 @@
     become: true
     become_user: root
 
+  - name: Install the Octavia Amphora Images
+    yum:
+      name:
+      - octavia-amphora-image-x86_64
+    become: true
+    become_user: root
+
   - name: Create standalone_parameters.yaml
     template:
       src: standalone_parameters.yaml.j2

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -22,8 +22,7 @@ parameter_defaults:
   InterfaceLocalMtu: 1500
   SELinuxMode: permissive
   StandaloneNetworkConfigTemplate: "{{ ansible_env.HOME }}/dev-install_net_config.yaml"
-  # These 2 Octavia parameters are required to be set even if we don't use the Amphora thanks
-  # to the OVN provider in Octavia.
   OctaviaGenerateCerts: true
   OctaviaCaKeyPassphrase: "secrete"
   OctaviaAmphoraSshKeyFile: "{{ ansible_env.HOME }}/octavia.pub"
+  OctaviaAmphoraImageFilename: /usr/share/openstack-octavia-amphora-images/octavia-amphora.qcow2


### PR DESCRIPTION
This is needed so Octavia works fine when Kuryr tries to bootstrap
loadbalancers used for l7 (not using OVN yet).

Also remove the comments that says that we don't use Amphora, this was
wrong.