### PR TITLE
Adds enabled_services as a list

### DIFF
--- a/playbooks/templates/tripleo-deploy.sh.j2
+++ b/playbooks/templates/tripleo-deploy.sh.j2
@@ -8,7 +8,9 @@ sudo openstack tripleo deploy \
     --local-ip={{ control_plane_ip }} \
     --control-virtual-ip {{ public_api }} \
     -e /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml \
-    -e /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml \
+{% for service in enabled_services %}
+    -e {{ service }} \
+{% endfor %}
     -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
     -e {{ stack_home }}/containers-prepare-parameters.yaml \
     -e {{ stack_home }}/standalone_parameters.yaml \

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -48,3 +48,6 @@ testconfig_public_key: ~/.ssh/id_rsa.pub
 cirros_url: http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img
 rhcos_meta_url: https://raw.githubusercontent.com/openshift/installer/master/data/data/rhcos.json
 # Define rhcos_url to override use of rhcos_meta_url
+
+enabled_services:
+  - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml


### PR DESCRIPTION
Allows user to customize what services to deploy (tripleo templates)
and  be included as "-e" flags to the "tripleo deploy" command