### PR TITLE
Changes related to network playbook

### DIFF
--- a/playbooks/roles/network_info/tasks/main.yaml
+++ b/playbooks/roles/network_info/tasks/main.yaml
@@ -1,7 +1,15 @@
 ---
+- name: Prepare dev-install directory in /var/lib
+  file:
+    path: /var/lib/dev-install
+    state: directory
+    owner: stack
+    group: stack
+    mode: 0775
+
 - name: Read network info if present
   slurp:
-    src: &networkinfo /etc/dev-install-network-info.yaml
+    src: &networkinfo /var/lib/dev-install/dev-install-network-info.yaml
   register: networkinfo_file
   ignore_errors: true
 
@@ -27,4 +35,6 @@
     copy:
       dest: *networkinfo
       content: "{{ network_info | to_nice_json }}"
+      owner: stack
+      group: stack
   when: networkinfo_file.failed

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -4,7 +4,6 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   use_dhcp: true
-  mtu: 1500
   ovs_extra:
   - br-set-external-id br-ex bridge-id br-ex
   members:
@@ -14,7 +13,6 @@ network_config:
 - type: ovs_bridge
   name: br-ctlplane
   use_dhcp: false
-  mtu: 1500
   ovs_extra:
   - br-set-external-id br-ctlplane bridge-id br-ctlplane
   addresses:
@@ -26,7 +24,6 @@ network_config:
 - type: ovs_bridge
   name: br-hostonly
   use_dhcp: false
-  mtu: 1500
   ovs_extra:
   - br-set-external-id br-hostonly bridge-id br-hostonly
   addresses:


### PR DESCRIPTION
- Makes dev-install-network-info.yaml accessible by stack user
         The file is created by the root user (become:yes), thus we need to setup the appropriate ownership/permissions to 
          allow stack user to access the file in following steps. 
- Removed MTUs from network definitions so they are derived from the interfaces added to the bridges.
       If the MTU is not specified by the bridge definition, os-net-config will use the mtus of the attached interfaces.
       Doing so is a better option because it avoids mismatch of mtus. for example, if the interface used for br-ex (eth0) is set to mtu 1400
       we also want the br-ex bridge to have its MTU set to 1400s. 
