### PR TITLE
Set the provider network as shared

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -93,7 +93,7 @@
   - name: Create hostonly network
     shell: |
       if ! openstack network show hostonly; then
-          openstack network create --project openshift --external --provider-physical-network hostonly --provider-network-type flat hostonly
+          openstack network create --project openshift --share --external --provider-physical-network hostonly --provider-network-type flat hostonly
       fi
       if ! openstack subnet show hostonly-subnet; then
           openstack subnet create --project openshift hostonly-subnet --subnet-range "{{ hostonly_cidr }}" \


### PR DESCRIPTION
So nova can schedule VMs on that network.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
