### PR TITLE
Install ceph-ansible

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -17,6 +17,7 @@
     yum:
       name:
       - python3-tripleoclient
+      - ceph-ansible
     become: true
     become_user: root
 


### PR DESCRIPTION
If Ceph is being deployed, we need ceph-ansible.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
