### PR TITLE
Few improvements (useful for Edge)

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -35,6 +35,7 @@
   - name: Install the tripleo client
     yum:
       name:
+      - ceph-ansible
       - python3-tripleoclient
     become: true
     become_user: root

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -1,7 +1,7 @@
 #vi:syntax=yaml
 
 parameter_defaults:
-  CloudName: {{ public_api }}
+  CloudName: {{ hostname }}.{{ clouddomain }}
   Debug: true
   DeploymentUser: {{ ansible_env.USER }}
   DnsServers:

--- a/playbooks/templates/tripleo-deploy.sh.j2
+++ b/playbooks/templates/tripleo-deploy.sh.j2
@@ -11,8 +11,9 @@ sudo openstack tripleo deploy \
 {% for service in enabled_services %}
     -e {{ service }} \
 {% endfor %}
-    -r /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml \
+    -r {{ standalone_role }} \
     -e {{ stack_home }}/containers-prepare-parameters.yaml \
     -e {{ stack_home }}/standalone_parameters.yaml \
     --output-dir {{ stack_home }} \
+    --keep-running \
     --standalone >> {{ tripleo_deploy_logs }}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -56,3 +56,4 @@ rhcos_meta_url: https://raw.githubusercontent.com/openshift/installer/master/dat
 
 enabled_services:
   - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
+standalone_role: /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml


### PR DESCRIPTION
* install ceph-ansible, which is required if you deploy Ceph in your
  cloud.
* Switch CloudName to be the FQDN of the cloud, not an IP address.
* Add a parameter to change the default role for Standalone
* Use --keep-running, so an operator can query the Heat ephemeral stack
  for standalone. Useful in the case of Edge since we need to extract
  Heat data like endpoint-map, etc.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
