### PR TITLE
certs: Add a `make certs` target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /local-overrides.yaml
 /scripts/env.sh
 /scripts/sshuttle-standalone.sh
+/simpleca
+/quay.cert
+/quay.csr
+/quay.key
 
 # From https://github.com/github/gitignore/blob/master/Global/Vim.gitignore
 # Swap

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ prepare_stack_testconfig: inventory.yaml local-overrides.yaml
 local_os_client: inventory.yaml local-overrides.yaml
 	$(ANSIBLE_CMD) playbooks/local_os_client.yaml
 
+.PHONY: certs
+certs: local-overrides.yaml
+	$(ANSIBLE_CMD) playbooks/certs.yaml
+
 .PHONY: destroy
 destroy: inventory.yaml local-overrides.yaml
 	$(ANSIBLE_CMD) playbooks/destroy.yaml

--- a/playbooks/certs.yaml
+++ b/playbooks/certs.yaml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  gather_facts: false
+  vars_files: vars/defaults.yaml
+  roles:
+  - role: simpleca
+    vars:
+      cert_user: quay
+      cert_name: "{{ standalone_host }}"

--- a/playbooks/roles/simpleca/defaults/main.yml
+++ b/playbooks/roles/simpleca/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+cert_dir: ..
+ca_dir: "{{ cert_dir}}/simpleca"

--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -1,0 +1,50 @@
+---
+# With thanks to https://milliams.com/posts/2020/ansible-certificate-authority/
+- name: Create the CA directory
+  file:
+    path: "{{ ca_dir }}"
+    state: directory
+    mode: '0750'
+
+- name: Create CA key
+  openssl_privatekey:
+    path: "{{ ca_dir }}/simpleca.key"
+  register: ca_key
+
+- name: Create the CA CSR
+  openssl_csr:
+    path: "{{ ca_dir }}/simpleca.csr"
+    privatekey_path: "{{ ca_key.filename }}"
+    common_name: "simpleca"
+    basic_constraints:
+    - "CA:TRUE"
+  register: ca_csr
+
+- name: Sign the CA CSR
+  openssl_certificate:
+    path: "{{ ca_dir }}/simpleca.cert"
+    csr_path: "{{ ca_csr.filename }}"
+    privatekey_path: "{{ ca_key.filename }}"
+    provider: selfsigned
+  register: ca_crt
+
+- name: Create a private key for {{ cert_user }}
+  openssl_privatekey:
+    path: "{{cert_dir}}/{{ cert_user }}.key"
+  register: user_key
+
+- name: Create a CSR for {{ cert_user }}
+  openssl_csr:
+    path: "{{cert_dir}}/{{ cert_user }}.csr"
+    privatekey_path: "{{ user_key.filename }}"
+    common_name: "{{ cert_name }}"
+    subject_alt_name: "DNS:{{ cert_name }}"
+  register: user_csr
+
+- name: Sign the CSR for {{ cert_user }}
+  openssl_certificate:
+    path: "{{cert_dir}}/{{ cert_user }}.cert"
+    csr_path: "{{ user_csr.filename }}"
+    provider: ownca
+    ownca_path: "{{ ca_crt.filename }}"
+    ownca_privatekey_path: "{{ ca_key.filename }}"


### PR DESCRIPTION
Generates root CA which passes validation by openshift-install when
passed in additionalTrustBundle.

Generates signed cert for quay service running on host.