### PR TITLE
certs: use crt vs cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /scripts/env.sh
 /scripts/sshuttle-standalone.sh
 /simpleca
-/quay.cert
+/quay.crt
 /quay.csr
 /quay.key
 

--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -22,7 +22,7 @@
 
 - name: Sign the CA CSR
   openssl_certificate:
-    path: "{{ ca_dir }}/simpleca.cert"
+    path: "{{ ca_dir }}/simpleca.crt"
     csr_path: "{{ ca_csr.filename }}"
     privatekey_path: "{{ ca_key.filename }}"
     provider: selfsigned
@@ -43,7 +43,7 @@
 
 - name: Sign the CSR for {{ cert_user }}
   openssl_certificate:
-    path: "{{cert_dir}}/{{ cert_user }}.cert"
+    path: "{{cert_dir}}/{{ cert_user }}.crt"
     csr_path: "{{ user_csr.filename }}"
     provider: ownca
     ownca_path: "{{ ca_crt.filename }}"


### PR DESCRIPTION
The right file extension for an openssl certificate is .crt.

Signed-off-by: Emilien Macchi <emilien@redhat.com>
