### PR TITLE
Enable advanced nic configs (e.g. SR-IOV)

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -1,6 +1,9 @@
 #vi:syntax=yaml
 ---
 network_config:
+{% if network_config is defined %}
+{{ network_config | to_nice_yaml }}
+{% else %}
 - type: ovs_bridge
   name: br-ex
   use_dhcp: true
@@ -38,3 +41,4 @@ network_config:
   - type: interface
     name: dummy1
     nm_controlled: true
+{% endif %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -20,6 +20,10 @@ control_plane_ip: 192.168.24.1
 # By default we use the default IP of the host
 public_api: "{{ network_info.public_ipv4.address }}"
 
+# For advanced network configurations (e.g. SR-IOV), network_config can be overriden
+# The format is for os-net-config, check dev-install_net_config.yaml.j2 template.
+# network_config
+
 # The `external` provider network
 # This will be created only if external_fip_pool_start and external_fip_pool_end
 # are manually defined.


### PR DESCRIPTION
Allow the user to override the network config when they know what
they're doing, if not we use the opinionated template like before.
