### PR TITLE
network: add iptables in dependencies

### DIFF
--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -16,6 +16,7 @@
       - rhosp-openvswitch
       - NetworkManager-ovs
       - nmstate
+      - iptables
     register: installovs
 
   - name: Restart NetworkManager to load ovs plugin


### PR DESCRIPTION
It's not installed by default on RHEL8 and needed for the nat rule to
be created.
