### PR TITLE
Add support to install Ceph via loop device

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -61,10 +61,16 @@
           ssh-keygen -b 2048 -t rsa -f "{{ ansible_env.HOME }}/octavia" -q -N ""
       fi
 
+  - name: Create ceph_env fact
+    set_fact:
+      ceph_env: /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml
+    when: ceph_enabled
+
   - name: Create default_tripleo_envs fact
     set_fact:
       default_tripleo_envs:
         - /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml
+        - "{{ ceph_env | default(omit) }}"
         - "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
         - "{{ ansible_env.HOME }}/standalone_parameters.yaml"
 

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -69,3 +69,39 @@
     user:
       name: stack
       groups: wheel
+  - name: Prepare host for Ceph
+    when: ceph_enabled
+    block:
+    - name: Make sure we have losetup installed/latest
+      package:
+        name:
+          - util-linux
+          - lvm2
+        state: latest
+    - name: Use dd and losetup to create the loop devices
+      shell: |
+        fallocate -l {{ ceph_loop_device_size }}G /var/lib/ceph-osd.img
+        losetup /dev/ceph-loopback /var/lib/ceph-osd.img
+        pvcreate /dev/ceph-loopback
+        vgcreate vg2 /dev/ceph-loopback
+        lvcreate -n data-lv2 --size {{ ceph_loop_device_size * 96 / 100 }}G vg2
+        lvcreate -n db-lv2 --size {{ (ceph_loop_device_size * 4 / 100) - 0.1 }}G vg2
+    - name: Create /etc/systemd/system/ceph-osd-losetup.service
+      copy:
+        dest: /etc/systemd/system/ceph-osd-losetup.service
+        content: |
+          [Unit]
+          Description=Ceph OSD losetup
+          After=syslog.target
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/bash -c '/sbin/losetup /dev/ceph-loopback || \
+          /sbin/losetup /dev/ceph-loopback /var/lib/ceph-osd.img ; partprobe /dev/ceph-loopback'
+          ExecStop=/sbin/losetup -d /dev/ceph-loopback
+          RemainAfterExit=yes
+          [Install]
+          WantedBy=multi-user.target
+    - name: Enable ceph-osd-losetup.service
+      systemd:
+        name: ceph-osd-losetup.service
+        enabled: true

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -69,8 +69,14 @@
       if ! openstack flavor show m1.large; then
           openstack flavor create --ram 8192 --disk 25 --vcpu 4 --public m1.large
       fi
+      if ! openstack flavor show m1.large.nodisk; then
+          openstack flavor create --ram 8192 --disk 0 --vcpu 4 --public m1.large.nodisk
+      fi
       if ! openstack flavor show m1.xlarge; then
           openstack flavor create --ram 16384 --disk 40 --vcpu 4 --public m1.xlarge
+      fi
+      if ! openstack flavor show m1.xlarge.nodisk; then
+          openstack flavor create --ram 16384 --disk 0 --vcpu 4 --public m1.xlarge.nodisk
       fi
     environment:
       OS_CLOUD: standalone

--- a/playbooks/roles/network_info/tasks/main.yaml
+++ b/playbooks/roles/network_info/tasks/main.yaml
@@ -16,12 +16,17 @@
     setup:
       gather_subset: "network"
 
+  - name: Set ip with netmask facts
+    set_fact:
+      public_ipv4_full: "{{ ansible_facts.default_ipv4.address + '/' + ansible_facts.default_ipv4.netmask }}"
+
   - name: Set network_info from gathered facts
     set_fact:
       network_info:
         dns: "{{ ansible_facts.dns.nameservers }}"
         public_ipv4: "{{ ansible_facts.default_ipv4 }}"
         public_ipv6: "{{ ansible_facts.default_ipv6 }}"
+        public_ipv4_cidr: "{{ public_ipv4_full | ipaddr('prefix') }}"
 
   - name: Write network_info to file
     copy:

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -33,3 +33,18 @@ parameter_defaults:
   OctaviaCaKeyPassphrase: "secrete"
   OctaviaAmphoraSshKeyFile: "{{ ansible_env.HOME }}/octavia.pub"
   OctaviaAmphoraImageFilename: "{{ ansible_env.HOME }}/amphora.qcow2"
+{% if ceph_enabled %}
+  CephAnsibleDisksConfig:
+    osd_scenario: lvm
+    osd_objectstore: bluestore
+    lvm_volumes:
+      - data: data-lv2
+        data_vg: vg2
+        db: db-lv2
+        db_vg: vg2
+  CephAnsibleExtraConfig:
+    cluster_network: {{ network_info.public_ipv4.network }}/{{ network_info.public_ipv4_cidr }}
+    public_network: {{ network_info.public_ipv4.network }}/{{ network_info.public_ipv4_cidr }}
+  CephPoolDefaultPgNum: 8
+  CephPoolDefaultSize: 1
+{% endif %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -85,3 +85,8 @@ neutron_flat_networks: "external,hostonly"
 tripleo_repos_repos:
   - current-tripleo-dev
   - ceph
+
+ceph_enabled: false
+# Size of the loop device that will be
+# used for Ceph (in GB).
+ceph_loop_device_size: 10


### PR DESCRIPTION
For the developer use case, we use a loop device to install LVM volumes
for ceph.
This patch will add two options to dev-install:

* ceph_enabled (false by default)
* ceph_loop_device_size (10 GB by default)

It will take care of creating a loop device that is reboot-persistent,
and then use it for the deployment of Ceph via ceph-ansible.
It'll also dynamically load the environment and services if we want
Ceph enabled.

This addition does not configure Ceph for production, so in the
OpenShift on OpenStack use-case, keep in mind that the Ceph
performances won't be great on loop devices. In other words, booting
the cluster nodes from volumes will be problematic because of perf
requirements for etcd.

It also adds nodisk flavors for both large and xlarge. They can be
useful when deploying OCP masters or workers with rootVolume from
Cinder (backend in Ceph).
