### PR TITLE
defaults: add missing namespace for OSP containers

### DIFF
--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -2,8 +2,10 @@
 rhos_release: 16.2
 cip_config:
   - set:
+      namespace: registry-proxy.engineering.redhat.com/rh-osbs
+      prefix: rhosp16-openstack-
       name_prefix: rhosp16-openstack-
-      tag: 16.2_20210426.1
+      tag: 16.2_20210420.1
       ceph-namespace: registry-proxy.engineering.redhat.com/rh-osbs
       ceph-image: rhceph
       ceph-tag: 4-36


### PR DESCRIPTION
My bad, I missed it in the last PR.
Also changing the tag to match with what is on tested already.
