### PR TITLE
Enable SR-IOV + DPDK support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,38 @@ When idle, a standalone deployment uses approximately:
 * 3.6G on /var/lib/nova
 
 There is no need to mount /var/lib/cinder and /var/lib/nova separately if / is large enough for your workload.
+
+## Advanced features
+
+### NFV enablement
+
+This section contains configuration procedures for single root input/output virtualization (SR-IOV) and
+dataplane development kit (DPDK) for network functions virtualization infrastructure (NFVi) in 
+your Standalone OpenStack deployment. 
+Unfortunately, most of these parameters don't have default values nor can be automatically figured out in
+a Standalone type environment.
+
+SR-IOV Variables
+----------------
+
+To understand how the SR-IOV configuration works, please have a look at this [upstream guide](https://docs.openstack.org/neutron/latest/admin/config-sriov.html).
+
+| Name              | Default Value       | Description          |
+|-------------------|---------------------|----------------------|
+| `sriov_services` | `['OS::TripleO::Services::NeutronSriovAgent', 'OS::TripleO::Services::BootParams']` | List of TripleO services to add to the default Standalone role |
+| `sriov_interface` | `[undefined]` | Name of the SR-IOV capable interface. Must be enabled in BIOS. e.g. `ens1f0` |
+| `sriov_nic_numvfs` | `[undefined]` | Number of Virtual Functions that the NIC can handle. |
+| `sriov_nova_pci_passthrough` | `[undefined]` | List of PCI Passthrough whitelist parameters. [Guidelines](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/configuring-pci-passthrough#guidelines-for-configuring-novapcipassthrough-osp) to configure it. |
+
+DPDK Variables
+--------------
+
+Please read the [official manual](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/network_functions_virtualization_planning_and_configuration_guide/index#concept_ovsdpdk-cpu-parameters)
+to understand better about the following parameters, they'll help you to figure out what values can be set, which
+couldn't be automatically set for you by dev-install.
+
+| Name              | Default Value       | Description          |
+|-------------------|---------------------|----------------------|
+| `dpdk_kernel_args` | `[undefined]` | Kernel arguments to configure when booting the machine. |
+| `dpdk_isol_cpus_list` | `[undefined]` | A set of CPU cores isolated from the host processes represented via a comma-separated list or range of physical host CPU numbers to which processes for pinned instance CPUs can be scheduled.
+| `dpdk_cpu_shared_set` | `[undefined]` | A comma-separated list or range of physical host CPU numbers used to determine the host CPUs for instance emulator threads.

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -13,6 +13,14 @@
     setup:
       gather_subset: min
 
+  - name: Install the tripleo client
+    yum:
+      name:
+      - ceph-ansible
+      - python3-tripleoclient
+    become: true
+    become_user: root
+
   - name: Create dev-install_net_config.yaml
     template:
       src: dev-install_net_config.yaml.j2
@@ -27,18 +35,34 @@
     set_fact:
       net_config_json: "{{ net_config['content'] | b64decode | from_yaml }}"
 
+  - name: Read the TripleO role
+    slurp:
+      src: "{{ standalone_role }}"
+    register: role_yaml
+
+  - name: Parse the role data
+    set_fact:
+      role_data: "{{ role_yaml['content'] | b64decode | from_yaml }}"
+
+  - name: Set fact for the new role data
+    set_fact:
+      new_role_data: "{{ role_data }}"
+
+  - name: Set the fact for overrides services
+    set_fact:
+      role_data: >
+        {% set _ = new_role_data.0.__setitem__('ServicesDefault', new_role_data.0.ServicesDefault | union(services_overrides)) %}
+        {{ new_role_data }}
+
+  - name: Create the new role file
+    copy:
+      dest: "{{ ansible_env.HOME }}/tripleo_standalone_role.yaml"
+      content: "{{ role_data }}"
+
   - name: Create standalone_parameters.yaml
     template:
       src: standalone_parameters.yaml.j2
       dest: "{{ ansible_env.HOME }}/standalone_parameters.yaml"
-
-  - name: Install the tripleo client
-    yum:
-      name:
-      - ceph-ansible
-      - python3-tripleoclient
-    become: true
-    become_user: root
 
   # The Amphora image is broken for OSP17, see:
   # https://review.rdoproject.org/r/32023
@@ -87,4 +111,4 @@
       tripleo_deploy_generate_scripts: true
       tripleo_deploy_keep_running: true
       tripleo_deploy_home_dir: "{{ ansible_env.HOME }}"
-      tripleo_deploy_roles_file: "{{ standalone_role }}"
+      tripleo_deploy_roles_file: "{{ ansible_env.HOME }}/tripleo_standalone_role.yaml"

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -35,6 +35,10 @@
     set_fact:
       net_config_json: "{{ net_config['content'] | b64decode | from_yaml }}"
 
+  - name: Set fact for SR-IOV services overrides
+    set_fact:
+      sriov_services_fact: "{{ sriov_interface | ternary(sriov_services, []) }}"
+
   - name: Read the TripleO role
     slurp:
       src: "{{ standalone_role }}"
@@ -51,7 +55,7 @@
   - name: Set the fact for overrides services
     set_fact:
       role_data: >
-        {% set _ = new_role_data.0.__setitem__('ServicesDefault', new_role_data.0.ServicesDefault | union(services_overrides)) %}
+        {% set _ = new_role_data.0.__setitem__('ServicesDefault', new_role_data.0.ServicesDefault | union(sriov_services_fact) | union(standalone_role_overrides)) %}
         {{ new_role_data }}
 
   - name: Create the new role file
@@ -90,6 +94,20 @@
         - /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml
     when: ceph_enabled
 
+  - name: Install all tuned profiles if SR-IOV is enabled
+    yum:
+      name:
+      - tuned-profiles-*
+    become: true
+    become_user: root
+    when: dpdk_kernel_args is defined
+
+  - name: Create sriov_env fact
+    set_fact:
+      sriov_env:
+        - /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovn-sriov.yaml
+    when: sriov_interface is defined
+
   - name: Create default_tripleo_envs fact
     set_fact:
       default_tripleo_envs:
@@ -107,8 +125,19 @@
       tripleo_deploy_output_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_local_ip: "{{ public_api }}"
       tripleo_deploy_control_virtual_ip: "{{ control_plane_ip }}"
-      tripleo_deploy_environment_files: "{{ default_tripleo_envs | union(enabled_services) | union(ceph_env|default([])) }}"
+      tripleo_deploy_environment_files: "{{ default_tripleo_envs | union(enabled_services) | union(ceph_env|default([])) | union(sriov_env|default([])) }}"
       tripleo_deploy_generate_scripts: true
       tripleo_deploy_keep_running: true
       tripleo_deploy_home_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_roles_file: "{{ ansible_env.HOME }}/tripleo_standalone_role.yaml"
+
+  - name: Reboot if SR-IOV is enabled (to apply kernel changes)
+    when:
+      - sriov_interface is defined
+    block:
+      - name: Reboot the node
+        become_user: root
+        reboot:
+      - name: Pause for 2 minutes to let all containers to start and OpenStack to be ready
+        pause:
+          minutes: 2

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -38,7 +38,18 @@ network_config:
   - destination: {{ hostonly_cidr }}
     nexthop: {{ hostonly_gateway }}
   members:
+{% if sriov_interface is defined %}
+  - type: sriov_pf
+    name: {{ sriov_interface }}
+    numvfs: {{ sriov_nic_numvfs | mandatory }}
+    use_dhcp: false
+    defroute: false
+    nm_controlled: false
+    hotplug: true
+    promisc: false
+{% else %}
   - type: interface
     name: dummy1
     nm_controlled: true
+{% endif %}
 {% endif %}

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -17,6 +17,17 @@ parameter_defaults:
   NeutronDnsDomain: {{ clouddomain }}
   NeutronBridgeMappings: {{ neutron_bridge_mappings }}
   NeutronFlatNetworks: {{ neutron_flat_networks }}
+{% if sriov_interface is defined %}
+  NeutronPhysicalDevMappings: "hostonly:{{ sriov_interface }}"
+  NovaPCIPassthrough: {{sriov_nova_pci_passthrough | mandatory | to_json }}
+{% endif %}
+{% if dpdk_kernel_args is defined %}
+  KernelArgs: "{{ dpdk_kernel_args | mandatory }}"
+  IsolCpusList: "{{ dpdk_isol_cpus_list | mandatory }}"
+  NovaComputeCpuDedicatedSet: "{{ dpdk_isol_cpus_list | mandatory }}"
+  NovaComputeCpuSharedSet: "{{ dpdk_cpu_shared_set | mandatory }}"
+  TunedProfileName: cpu-partitioning
+{% endif %}
   StandaloneEnableRoutedNetworks: false
   StandaloneHomeDir: "{{ ansible_env.HOME }}"
   InterfaceLocalMtu: 1500
@@ -33,6 +44,9 @@ parameter_defaults:
   OctaviaCaKeyPassphrase: "secrete"
   OctaviaAmphoraSshKeyFile: "{{ ansible_env.HOME }}/octavia.pub"
   OctaviaAmphoraImageFilename: "{{ ansible_env.HOME }}/amphora.qcow2"
+  # We never want the node to reboot during tripleo deploy, but defer to later
+  StandaloneExtraGroupVars:
+    tripleo_kernel_defer_reboot: true
 {% if ceph_enabled %}
   CephAnsibleDisksConfig:
     osd_scenario: lvm

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -78,6 +78,9 @@ rhcos_meta_url: https://raw.githubusercontent.com/openshift/installer/master/dat
 enabled_services:
   - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
 standalone_role: /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml
+# List of TripleO services that we want to add in the role defined in standalone_role.
+# e.g. ['OS::TripleO::Services::CinderVolumeEdge', 'OS::TripleO::Services::Etcd']
+standalone_role_overrides: []
 
 # This variable allows to add extra Heat parameters to standalone_parameters.yaml.
 # e.g.  extra_heat_params:

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -103,3 +103,14 @@ ceph_enabled: false
 # Size of the loop device that will be
 # used for Ceph (in GB).
 ceph_loop_device_size: 10
+
+sriov_services:
+  - OS::TripleO::Services::NeutronSriovAgent
+  - OS::TripleO::Services::BootParams
+#sriov_interface:
+#sriov_nic_numvfs:
+#sriov_nova_pci_passthrough:
+
+#dpdk_kernel_args:
+#dpdk_isol_cpus_list:
+#dpdk_cpu_shared_set:


### PR DESCRIPTION
* Add an interface to easily add new services into the default Standalone role.
* Make it so SR-IOV and DPDK configs are independently configurable
* Configure SR-IOV + DPDK parameters in standalone_parameters.
* Configure the SR-IOV NIC.
* Modify the Standalone role with SR-IOV services
* Reboot the node at the end of the deployment to apply Kernel changes.