### PR TITLE
ceph: fix loop device name

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -81,9 +81,9 @@
     - name: Use dd and losetup to create the loop devices
       shell: |
         fallocate -l {{ ceph_loop_device_size }}G /var/lib/ceph-osd.img
-        losetup /dev/ceph-loopback /var/lib/ceph-osd.img
-        pvcreate /dev/ceph-loopback
-        vgcreate vg2 /dev/ceph-loopback
+        losetup /dev/loop1 /var/lib/ceph-osd.img
+        pvcreate /dev/loop1
+        vgcreate vg2 /dev/loop1
         lvcreate -n data-lv2 --size {{ ceph_loop_device_size * 96 / 100 }}G vg2
         lvcreate -n db-lv2 --size {{ (ceph_loop_device_size * 4 / 100) - 0.1 }}G vg2
     - name: Create /etc/systemd/system/ceph-osd-losetup.service
@@ -95,9 +95,9 @@
           After=syslog.target
           [Service]
           Type=oneshot
-          ExecStart=/bin/bash -c '/sbin/losetup /dev/ceph-loopback || \
-          /sbin/losetup /dev/ceph-loopback /var/lib/ceph-osd.img ; partprobe /dev/ceph-loopback'
-          ExecStop=/sbin/losetup -d /dev/ceph-loopback
+          ExecStart=/bin/bash -c '/sbin/losetup /dev/loop1 || \
+          /sbin/losetup /dev/loop1 /var/lib/ceph-osd.img ; partprobe /dev/loop1'
+          ExecStop=/sbin/losetup -d /dev/loop1
           RemainAfterExit=yes
           [Install]
           WantedBy=multi-user.target


### PR DESCRIPTION
We can't customize the loop device name (it errors), so let's just use
loop1 like it's done by standard loops.
