### PR TITLE
A mix of QoL and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,8 @@ external interface on to that bridge. This bridge is used to provide the
 `external` provider network if `external_fip_pool_start` and
 `external_fip_pool_end` are defined in `local-overrides.yaml`.
 
-In addition it will create OVS bridges called br-ctlplane and br-hostonly. The
-former is used internally by OSP. The latter is a second provider network which
-is only routable from the host.
+In addition it will create an OVS bridge br-hostonly. This is a second provider
+network which is only routable from the host.
 
 Note that we don't enable DHCP on provider networks by default, and it is not
 recommended to enable DHCP on the external network at all. To enable DHCP on the

--- a/example-overrides/local-overrides-centos8-tripleo-train.yaml
+++ b/example-overrides/local-overrides-centos8-tripleo-train.yaml
@@ -1,7 +1,4 @@
 standalone_host: <standalone FQDN>
-# Both public_api and control_plane_ip have to be the same in OSP16 for Pacemaker
-public_api: <IP address used to reach the node>
-control_plane_ip: <Same IP address used to reach the node>
 tripleo_repos_branch: train
 cip_config:
   - set:

--- a/example-overrides/local-overrides-osp16-2.yaml
+++ b/example-overrides/local-overrides-osp16-2.yaml
@@ -1,7 +1,4 @@
 standalone_host: <standalone FQDN>
-# Both public_api and control_plane_ip have to be the same in OSP16 for Pacemaker
-public_api: <IP address used to reach the node>
-control_plane_ip: <Same IP address used to reach the node>
 # Get latest 16.2 puddle
 rhos_release: 16.2
 cip_config:

--- a/example-overrides/local-overrides-osp16-2.yaml
+++ b/example-overrides/local-overrides-osp16-2.yaml
@@ -1,9 +1,3 @@
 standalone_host: <standalone FQDN>
 # Get latest 16.2 puddle
 rhos_release: 16.2
-cip_config:
-  - set:
-      namespace: registry-proxy.engineering.redhat.com/rh-osbs
-      name_prefix: rhosp16-openstack-
-      # This is subject to change, you should rely on what rhos-release provides
-      tag: 16.2_20210318.1

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -81,11 +81,34 @@
       url: https://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
       dest: "{{ ansible_env.HOME }}/amphora.qcow2"
 
+  - name: Set cip_config from downloaded container_image_prepare.yaml
+    when: cip_config is not defined
+    block:
+    - name: Read container_image_prepare.yaml
+      slurp:
+        src: /home/stack/container_image_prepare.yaml
+      register: cip_yaml
+    - set_fact:
+        cip_raw: "{{ (cip_yaml.content | b64decode | from_yaml)['container-image-prepare'] | dict2items }}"
+    - set_fact:
+        cip_config: "{{ [{ 'set': dict(keys | zip(values)) }] }}"
+      vars:
+        # container_image_prepare.yaml downloaded from the puddle contains some
+        # keys with invalid names, e.g. 'ceph-namespace' instead of
+        # 'ceph_namespace'. We rewrite them.
+        keys: "{{ cip_raw | map(attribute='key') | map('regex_replace', '-', '_') | list }}"
+        values: "{{ cip_raw | map(attribute='value') | list }}"
+
   - name: Create containers-prepare-parameters.yaml
-    template:
-      mode: 0644
-      src: containers-prepare-parameters.yaml.j2
+    copy:
       dest: "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
+      content: "{{ cip_content | to_nice_yaml }}"
+      owner: stack
+      mode: 0644
+    vars:
+      cip_content:
+        parameter_defaults:
+          ContainerImagePrepare: "{{ cip_config }}"
 
   - name: Generate a keypair for Octavia Amphora (needed by TripleO)
     shell: |

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -131,7 +131,7 @@
       tripleo_deploy_standalone: true
       tripleo_deploy_output_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_local_ip: "{{ public_api }}"
-      tripleo_deploy_control_virtual_ip: "{{ control_plane_ip }}"
+      tripleo_deploy_control_virtual_ip: "{{ public_api }}"
       tripleo_deploy_environment_files: "{{ default_tripleo_envs | union(enabled_services) | union(ceph_env|default([])) | union(sriov_env|default([])) }}"
       tripleo_deploy_generate_scripts: true
       tripleo_deploy_keep_running: true

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -39,13 +39,6 @@
     vars:
       network_state:
         interfaces:
-        - name: dummy0
-          type: dummy
-          state: up
-          ipv4:
-            enabled: false
-          ipv6:
-            enabled: false
         - name: dummy1
           type: dummy
           state: up

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -32,20 +32,43 @@
       enabled: true
       state: started
 
+  - name: Get list of network interfaces
+    command: nmstatectl show --json
+    register: nmstatectl
+
+  # Add the dummy1 interface
+  - set_fact:
+      configure_interfaces:
+      - name: dummy1
+        type: dummy
+        state: up
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+
+  # Disable all interfaces which we are not using.
+  # This prevents a later failure in the network systemd unit
+  - set_fact:
+      configure_interfaces: "{{ configure_interfaces + [ { 'name': item } | combine(disabled) ] }}"
+    loop: "{{ all_interfaces | difference(used_interfaces) }}"
+    vars:
+      all_interfaces: "{{ (nmstatectl.stdout | from_json)['interfaces'] | map(attribute='name') | list }}"
+      used_interfaces: "{{ [ 'lo', network_info.public_ipv4.interface ] + (sriov_interface is defined | ternary([sriov_interface], [])) }}"
+      disabled:
+        state: down
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+
   - name: Set nmstate # noqa 301
     command: nmstatectl set --no-commit --timeout 60
     args:
       stdin: "{{ network_state | to_nice_json }}"
     vars:
       network_state:
-        interfaces:
-        - name: dummy1
-          type: dummy
-          state: up
-          ipv4:
-            enabled: false
-          ipv6:
-            enabled: false
+        interfaces: "{{ configure_interfaces }}"
     register: nmstateset
 
   # Doing this in 2 steps means that we'll automatically rollback if we break

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -78,14 +78,10 @@
           - util-linux
           - lvm2
         state: present
-    - name: Use dd and losetup to create the loop devices
-      shell: |
-        fallocate -l {{ ceph_loop_device_size }}G /var/lib/ceph-osd.img
-        losetup /dev/loop1 /var/lib/ceph-osd.img
-        pvcreate /dev/loop1
-        vgcreate vg2 /dev/loop1
-        lvcreate -n data-lv2 --size {{ ceph_loop_device_size * 96 / 100 }}G vg2
-        lvcreate -n db-lv2 --size {{ (ceph_loop_device_size * 4 / 100) - 0.1 }}G vg2
+    - name: Create a backing file for ceph
+      command: /usr/bin/fallocate -l {{ ceph_loop_device_size }}G /var/lib/ceph-osd.img
+      args:
+        creates: /var/lib/ceph-osd.img
     - name: Create /etc/systemd/system/ceph-osd-losetup.service
       copy:
         dest: /etc/systemd/system/ceph-osd-losetup.service
@@ -96,8 +92,7 @@
           After=syslog.target
           [Service]
           Type=oneshot
-          ExecStart=/bin/bash -c '/sbin/losetup /dev/loop1 || \
-          /sbin/losetup /dev/loop1 /var/lib/ceph-osd.img ; partprobe /dev/loop1'
+          ExecStart=/bin/bash -c '/sbin/losetup /dev/loop1 || /sbin/losetup /dev/loop1 /var/lib/ceph-osd.img'
           ExecStop=/sbin/losetup -d /dev/loop1
           RemainAfterExit=yes
           [Install]
@@ -106,3 +101,18 @@
       systemd:
         name: ceph-osd-losetup.service
         enabled: true
+        state: started
+    - name: Create volume group for ceph
+      lvg:
+        vg: vg_ceph
+        pvs: /dev/loop1
+    - name: Create ceph data LV
+      lvol:
+        vg: vg_ceph
+        lv: data
+        size: 96%VG
+    - name: Create ceph db LV
+      lvol:
+        vg: vg_ceph
+        lv: db
+        size: 4%VG

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -7,6 +7,11 @@
 
   tasks:
 
+  - name: Create the stack user
+    user:
+      name: stack
+      groups: wheel
+
   - name: Prepare host on RHEL system
     when:
       - ansible_facts.distribution == 'RedHat'
@@ -18,9 +23,6 @@
           - http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
           disable_gpg_check: True
 
-      - name: Configure rhos release "{{ rhos_release }}"
-        command: rhos-release "{{ rhos_release }}"
-
       - name: Fetch the Red Hat root certificate
         get_url:
           dest: /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
@@ -30,6 +32,20 @@
         shell: |
           update-ca-trust enable
           update-ca-trust extract
+
+      - name: Configure rhos release "{{ rhos_release }}" and keep puddle name
+        shell: rhos-release "{{ rhos_release }}" | awk '/^# rhos-release/ { print $5 }'
+        register: rhos_release_puddle
+
+      - set_fact:
+          puddle: "{{ rhos_release_puddle.stdout_lines.0 }}"
+
+      - name: Download container_image_prepare.yaml for "{{ puddle }}"
+        get_url:
+          url: "http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/OpenStack/{{ rhos_release }}-RHEL-8/{{ puddle }}/container_image_prepare.yaml"
+          dest: /home/stack/container_image_prepare.yaml
+          owner: stack
+          group: stack
 
   - name: Prepare host on CentOS system
     when:
@@ -65,10 +81,6 @@
       line: '%wheel ALL=(ALL) NOPASSWD: ALL'
       validate: 'visudo -cf %s'
 
-  - name: Create the stack user
-    user:
-      name: stack
-      groups: wheel
   - name: Prepare host for Ceph
     when: ceph_enabled
     block:

--- a/playbooks/templates/containers-prepare-parameters.yaml.j2
+++ b/playbooks/templates/containers-prepare-parameters.yaml.j2
@@ -1,2 +1,0 @@
-parameter_defaults:
-  ContainerImagePrepare: {{ cip_config }}

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -15,18 +15,6 @@ network_config:
     name: {{ network_info.public_ipv4.interface }}
     primary: true
 - type: ovs_bridge
-  name: br-ctlplane
-  use_dhcp: false
-  mtu: 1500
-  ovs_extra:
-  - br-set-external-id br-ctlplane bridge-id br-ctlplane
-  addresses:
-  - ip_netmask: {{ control_plane_ip }}/32
-  members:
-  - type: interface
-    name: dummy0
-    nm_controlled: true
-- type: ovs_bridge
   name: br-hostonly
   use_dhcp: false
   mtu: 1500

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -11,7 +11,7 @@ parameter_defaults:
   # needed for vip & pacemaker
   KernelIpNonLocalBind: 1
   DockerInsecureRegistryAddress:
-    - {{ control_plane_ip }}:8787
+    - {{ public_api }}:8787
   # domain name used by the host
   CloudDomain: {{ clouddomain }}
   NeutronDnsDomain: {{ clouddomain }}

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -21,8 +21,10 @@ parameter_defaults:
   NeutronPhysicalDevMappings: "hostonly:{{ sriov_interface }}"
   NovaPCIPassthrough: {{sriov_nova_pci_passthrough | mandatory | to_json }}
 {% endif %}
+{% if kernel_args|length > 0 %}
+  KernelArgs: "{{ kernel_args | join(' ') }}"
+{% endif %}
 {% if dpdk_kernel_args is defined %}
-  KernelArgs: "{{ dpdk_kernel_args | mandatory }}"
   IsolCpusList: "{{ dpdk_isol_cpus_list | mandatory }}"
   NovaComputeCpuDedicatedSet: "{{ dpdk_isol_cpus_list | mandatory }}"
   NovaComputeCpuSharedSet: "{{ dpdk_cpu_shared_set | mandatory }}"

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -52,10 +52,10 @@ parameter_defaults:
     osd_scenario: lvm
     osd_objectstore: bluestore
     lvm_volumes:
-      - data: data-lv2
-        data_vg: vg2
-        db: db-lv2
-        db_vg: vg2
+      - data: data
+        data_vg: vg_ceph
+        db: db
+        db_vg: vg_ceph
   CephAnsibleExtraConfig:
     cluster_network: {{ network_info.public_ipv4.network }}/{{ network_info.public_ipv4_cidr }}
     public_network: {{ network_info.public_ipv4.network }}/{{ network_info.public_ipv4_cidr }}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -28,10 +28,6 @@ clouddomain: shiftstack
 # called `standalone`.
 local_cloudname: standalone
 
-# The control plane IP address allocated to br-ctlplane
-# You probably won't need to change this
-control_plane_ip: 192.168.24.1
-
 # The IP address of the public openstack endpoints
 # By default we use the default IP of the host
 public_api: "{{ network_info.public_ipv4.address }}"

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -95,10 +95,10 @@ tripleo_repos_repos:
   - current-tripleo-dev
   - ceph
 
-ceph_enabled: false
+ceph_enabled: true
 # Size of the loop device that will be
 # used for Ceph (in GB).
-ceph_loop_device_size: 10
+ceph_loop_device_size: 100
 
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -82,10 +82,16 @@ ceph_loop_device_size: 100
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent
   - OS::TripleO::Services::BootParams
+sriov_kernel_args_default:
+- "intel_iommu=on"
+- "iommu=pt"
 #sriov_interface:
 #sriov_nic_numvfs:
 #sriov_nova_pci_passthrough:
+sriov_kernel_args: "{{ (sriov_interface is defined) | ternary(sriov_kernel_args_default, []) }}"
 
 #dpdk_kernel_args:
 #dpdk_isol_cpus_list:
 #dpdk_cpu_shared_set:
+
+kernel_args: "{{ sriov_kernel_args + (dpdk_kernel_args | default([])) }}"

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -1,26 +1,5 @@
 ---
 rhos_release: 16.2
-cip_config:
-  - set:
-      namespace: registry-proxy.engineering.redhat.com/rh-osbs
-      prefix: rhosp16-openstack-
-      name_prefix: rhosp16-openstack-
-      tag: 16.2_20210420.1
-      ceph_namespace: registry-proxy.engineering.redhat.com/rh-osbs
-      ceph_image: rhceph
-      ceph_tag: 4-36
-      ceph_alertmanager_image: openshift-ose-prometheus-alertmanager
-      ceph_alertmanager_namespace: registry-proxy.engineering.redhat.com/rh-osbs
-      ceph_alertmanager_tag: v4.1
-      ceph_grafana_image: rhceph-3-dashboard-rhel7
-      ceph_grafana_namespace: registry.access.redhat.com/rhceph
-      ceph_grafana_tag: 3
-      ceph_node_exporter_image: openshift-ose-prometheus-node-exporter
-      ceph_node_exporter_namespace: registry-proxy.engineering.redhat.com/rh-osbs
-      ceph_node_exporter_tag: v4.1
-      ceph_prometheus_image: openshift-ose-prometheus
-      ceph_prometheus_namespace: registry-proxy.engineering.redhat.com/rh-osbs
-      ceph_prometheus_tag: v4.1
 hostname: standalone
 clouddomain: shiftstack
 


### PR DESCRIPTION
Reduce required configuration:
* Remove control_plane_ip
* Configure cip_config automatically from puddle
* Enable ceph by default (but you can still disable it)
* Allow SR-IOV without DPDK

Fixes:
* Idempotent ceph vg creation means you can re-run prepare_host
* Fix network systemd unit by disabling unused interfaces