### PR TITLE
If ceph is enable, disable Nova RBD

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -48,6 +48,13 @@ parameter_defaults:
   StandaloneExtraGroupVars:
     tripleo_kernel_defer_reboot: true
 {% if ceph_enabled %}
+  # Since we use a loop device for Ceph disk, performances wouldn't be great enough
+  # to boot VMs with heavy workloads on it.
+  # This can be overriden by setting:
+  # extra_heat_params:
+  #   NovaEnableRbdBackend: true
+  # But to use at your own risks.
+  NovaEnableRbdBackend: false
   CephAnsibleDisksConfig:
     osd_scenario: lvm
     osd_objectstore: bluestore


### PR DESCRIPTION
Since we use a loop device for the Ceph disk, performances wouldn't be
great enough to boot VMs (e.g. OCP cluster) and would lead to problems
later.
If anyone wants wants to overrides this option, they can do it via:

```
extra_heat_params:
  NovaEnableRbdBackend: true
```
To use at your own risks...
