### PR TITLE
Ensure standalone_parameters.yaml is last in tripleo deploy

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -13,6 +13,10 @@
     setup:
       gather_subset: min
 
+  - name: Initialise service environment list from user provided services
+    set_fact:
+      service_envs: "{{ enabled_services }}"
+
   - name: Install the tripleo client
     yum:
       name:
@@ -72,14 +76,32 @@
       src: standalone_parameters.yaml.j2
       dest: "{{ ansible_env.HOME }}/standalone_parameters.yaml"
 
-  # The Amphora image is broken for OSP17, see:
-  # https://review.rdoproject.org/r/32023
-  # Until then this is fine (tested) to use the latest
-  # image from RDO:
-  - name: Download the latest Amphora image for Octavia
-    get_url:
-      url: https://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
-      dest: "{{ ansible_env.HOME }}/amphora.qcow2"
+  - name: Enable Octavia
+    when: octavia_enabled
+    block:
+      # The Amphora image is broken for OSP17, see:
+      # https://review.rdoproject.org/r/32023
+      # Until then this is fine (tested) to use the latest
+      # image from RDO:
+      - name: Download the latest Amphora image for Octavia
+        get_url:
+          url: https://images.rdoproject.org/octavia/master/amphora-x64-haproxy-centos.qcow2
+          dest: "{{ ansible_env.HOME }}/amphora.qcow2"
+
+      - name: Generate a keypair for Octavia Amphora (needed by TripleO)
+        shell: |
+          if [ ! -f "{{ ansible_env.HOME }}/octavia" ]; then
+              ssh-keygen -b 2048 -t rsa -f "{{ ansible_env.HOME }}/octavia" -q -N ""
+          fi
+        args:
+          creates: "{{ ansible_env.HOME }}/octavia"
+
+      - name: Add octavia to enabled services
+        set_fact:
+          service_envs: "{{ service_envs | union(octavia_env) }}"
+        vars:
+          octavia_env:
+            - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
 
   - name: Create containers-prepare-parameters.yaml
     template:
@@ -87,16 +109,10 @@
       src: containers-prepare-parameters.yaml.j2
       dest: "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
 
-  - name: Generate a keypair for Octavia Amphora (needed by TripleO)
-    shell: |
-      if [ ! -f "{{ ansible_env.HOME }}/octavia" ]; then
-          ssh-keygen -b 2048 -t rsa -f "{{ ansible_env.HOME }}/octavia" -q -N ""
-      fi
-    args:
-      creates: "{{ ansible_env.HOME }}/octavia"
-
-  - name: Create ceph_env fact
+  - name: Add ceph to enabled services
     set_fact:
+      service_envs: "{{ service_envs | union(ceph_env) }}"
+    vars:
       ceph_env:
         - /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml
     when: ceph_enabled
@@ -109,8 +125,10 @@
     become_user: root
     when: dpdk_kernel_args is defined
 
-  - name: Create sriov_env fact
+  - name: Add sriov to enabled services
     set_fact:
+      service_envs: "{{ service_envs | union(sriov_env) }}"
+    vars:
       sriov_env:
         - /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovn-sriov.yaml
     when: sriov_interface is defined
@@ -120,6 +138,10 @@
       default_tripleo_envs:
         - /usr/share/openstack-tripleo-heat-templates/environments/standalone/standalone-tripleo.yaml
         - "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
+
+  - name: Create tripleo_override_envs fact
+    set_fact:
+      tripleo_override_envs:
         - "{{ ansible_env.HOME }}/standalone_parameters.yaml"
 
   - name: Run TripleO deploy
@@ -132,7 +154,7 @@
       tripleo_deploy_output_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_local_ip: "{{ public_api }}"
       tripleo_deploy_control_virtual_ip: "{{ control_plane_ip }}"
-      tripleo_deploy_environment_files: "{{ default_tripleo_envs | union(enabled_services) | union(ceph_env|default([])) | union(sriov_env|default([])) }}"
+      tripleo_deploy_environment_files: "{{ default_tripleo_envs + service_envs + tripleo_override_envs }}"
       tripleo_deploy_generate_scripts: true
       tripleo_deploy_keep_running: true
       tripleo_deploy_home_dir: "{{ ansible_env.HOME }}"

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -75,8 +75,7 @@ cirros_url: http://download.cirros-cloud.net/0.5.1/cirros-0.5.1-x86_64-disk.img
 rhcos_meta_url: https://raw.githubusercontent.com/openshift/installer/master/data/data/rhcos.json
 # Define rhcos_url to override use of rhcos_meta_url
 
-enabled_services:
-  - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
+enabled_services: []
 standalone_role: /usr/share/openstack-tripleo-heat-templates/roles/Standalone.yaml
 # List of TripleO services that we want to add in the role defined in standalone_role.
 # e.g. ['OS::TripleO::Services::CinderVolumeEdge', 'OS::TripleO::Services::Etcd']
@@ -103,6 +102,8 @@ ceph_enabled: false
 # Size of the loop device that will be
 # used for Ceph (in GB).
 ceph_loop_device_size: 10
+
+octavia_enabled: true
 
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent


### PR DESCRIPTION
Loading standalone_parameters.yaml early meant that values would be
overridden by defaults specified in subsequent environments.
Specifically this prevented NovaEnableRbdBackend: false working because
ceph enables it by default, and ceph was loaded later.