### PR TITLE
Configure the right MTU for br-ex

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -7,7 +7,7 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   use_dhcp: true
-  mtu: 1500
+  mtu: {{ network_info.public_ipv4.mtu }}
   ovs_extra:
   - br-set-external-id br-ex bridge-id br-ex
   members:


### PR DESCRIPTION
If the interface that is used for br-ex (e.g. eth0) had a specific MTU,
we need to configure the bridge with the right MTU value otherwise we
force it to 1500 and it can causes issues.
