### PR TITLE
clouds.yaml: configure volume_api_version

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -138,6 +138,7 @@
           username: openshift
         cacert: "{{ standalone['cacert'] }}"
         identity_api_version: "{{ standalone['identity_api_version'] }}"
+        volume_api_version: "{{ standalone['volume_api_version'] }}"
         region_name: "{{ standalone['region_name'] }}"
 
   - name: Write updated clouds.yaml


### PR DESCRIPTION
It's needed otherwise it defaults to Cinder V2 API.
