### PR TITLE
Allow to maintain multiple override files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /inventory.yaml
-/local-overrides.yaml
+/local-overrides*
 /scripts/env.sh
 /scripts/sshuttle-standalone.sh
 /simpleca

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@
 host ?= my_osp_host
 user ?= root
 ansible_args ?=
+overrides ?= local-overrides.yaml
 
-ANSIBLE_CMD=ANSIBLE_FORCE_COLOR=true ansible-playbook $(ansible_args) -i inventory.yaml -e @local-overrides.yaml
+ANSIBLE_CMD=ANSIBLE_FORCE_COLOR=true ansible-playbook $(ansible_args) -i inventory.yaml -e @$(overrides)
 
 usage:
 	@echo 'Usage:'
@@ -37,8 +38,8 @@ config: inventory.yaml local-overrides.yaml
 inventory.yaml:
 	echo -e "all:\n  hosts:\n    standalone:\n      ansible_host: $(host)\n      ansible_user: $(user)\n" > $@
 
-local-overrides.yaml:
-	echo -e "# Override default variables by putting them in this file\nstandalone_host: $(host)" > $@
+$(overrides):
+	echo -e "# Override default variables by putting them in this file\nstandalone_host: $(host)" > $(overrides)
 
 
 #
@@ -49,37 +50,37 @@ local-overrides.yaml:
 osp_full: local_requirements prepare_host network install_stack prepare_stack
 
 .PHONY: local_requirements
-local_requirements: inventory.yaml local-overrides.yaml
+local_requirements: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/local_requirements.yaml
 
 .PHONY: prepare_host
-prepare_host: inventory.yaml local-overrides.yaml
+prepare_host: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/prepare_host.yaml
 
 .PHONY: network
-network: inventory.yaml local-overrides.yaml
+network: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/network.yaml
 
 .PHONY: install_stack
-install_stack: inventory.yaml local-overrides.yaml
+install_stack: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/install_stack.yaml
 
 .PHONY: prepare_stack
-prepare_stack: inventory.yaml local-overrides.yaml
+prepare_stack: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/prepare_stack.yaml
 
 .PHONY: prepare_stack_testconfig
-prepare_stack_testconfig: inventory.yaml local-overrides.yaml
+prepare_stack_testconfig: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/prepare_stack_testconfig.yaml
 
 .PHONY: local_os_client
-local_os_client: inventory.yaml local-overrides.yaml
+local_os_client: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/local_os_client.yaml
 
 .PHONY: certs
-certs: local-overrides.yaml
+certs: $(overrides)
 	$(ANSIBLE_CMD) playbooks/certs.yaml
 
 .PHONY: destroy
-destroy: inventory.yaml local-overrides.yaml
+destroy: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/destroy.yaml

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Both of these files can be safely modified.
 
 `make osp_full` performs the actual installation. On an example system with 12 cores and 192GB RAM and running in a Red Hat data centre this takes approximately 65 minutes to execute.
 
+If you deal with multiple OpenStack clouds and want to maintain a single local-overrides per cloud, you can create `local-overrides-<name>.yaml`
+and then use it when deploying with `make osp_full overrides=local-overrides-<name>.yaml`
+
 ## Accessing OpenStack from your workstation
 
 By default, dev-install configures OpenStack to use the default public IP of the


### PR DESCRIPTION
Most of us maintain multiple overrides depending where they deploy.
Let's allow our users to maintain multiple files, e.g.:

- local-overrides-beaker.yaml
- local-overrides-vexxhost.yaml
- etc

And when deploying they do: `make osp_full
overrides=local-overrides-beaker.yaml`.

This is backward compatible and the default will remain
local-overrides.yaml.
