### PR TITLE
Add pre-deploy validations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ usage:
 	@echo
 	@echo 'Individual install phase targets:'
 	@echo '  local_requirements: Install Ansible requirements required to run dev-install'
+	@echo '  validations: Run some validations before the deployment'
 	@echo '  prepare_host: Host configuration required before installing standalone, including rhos-release'
 	@echo '  network: Host networking configuration required before installing standalone'
 	@echo '  install_stack: Install TripleO standalone'
@@ -50,11 +51,15 @@ $(overrides):
 #
 
 .PHONY: osp_full
-osp_full: local_requirements prepare_host network install_stack prepare_stack
+osp_full: local_requirements validations prepare_host network install_stack prepare_stack
 
 .PHONY: local_requirements
 local_requirements: inventory.yaml $(overrides)
 	$(ANSIBLE_CMD) playbooks/local_requirements.yaml
+
+.PHONY: validations
+validations: inventory.yaml $(overrides)
+	$(ANSIBLE_CMD) playbooks/validations.yaml
 
 .PHONY: prepare_host
 prepare_host: inventory.yaml $(overrides)

--- a/playbooks/validations.yaml
+++ b/playbooks/validations.yaml
@@ -1,0 +1,31 @@
+---
+- hosts: standalone
+  gather_facts: false
+  vars_files: vars/defaults.yaml
+
+  tasks:
+
+    - name: Check if inventory matches with standalone_host
+      assert:
+        that:
+          - standalone_host == ansible_host
+        fail_msg: >
+          Your inventory does not match with standalone_host set to '{{ standalone_host }}'
+          and ansible_host in the inventory set to '{{ ansible_host }}', which could
+          lead to a deployment on the wrong host
+        success_msg: 'standalone_host matches with ansible_host, target is valid'
+
+    - name: Check if control plane IP is different from the public IP
+      assert:
+        that:
+          - control_plane_ip != public_api
+        fail_msg: >
+          You must set different IP addresses for control_plane_ip and public_api otherwise
+          the deployment of OpenStack will fail.
+        success_msg: 'control plane IP is different from the public IP'
+
+    - name: Check that Standalone role file exists
+      stat:
+        path: "{{ standalone_role }}"
+      register: standalone_role_stat_result
+      failed_when: not standalone_role_stat_result.stat.exists


### PR DESCRIPTION
Add some variable validations, to prevent deployment issues later:

* standalone_host matches with ansible_host
* control_plane_ip is different from public_api
* standalone_role file actually exists
