### PR TITLE
Set default for volume_api_version

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -138,7 +138,7 @@
           username: openshift
         cacert: "{{ standalone['cacert'] }}"
         identity_api_version: "{{ standalone['identity_api_version'] }}"
-        volume_api_version: "{{ standalone['volume_api_version'] }}"
+        volume_api_version: "{{ standalone['volume_api_version'] | default('3') }}"
         region_name: "{{ standalone['region_name'] }}"
 
   - name: Write updated clouds.yaml


### PR DESCRIPTION
It seems like that admin credentials created by TripleO
don't have a volume_api_version so we need to set a default for the
openshift user (otherwise it fails to destroy OCP cluster).

'3' is a safe default that works for both OSP16 and tripleo master.
