### PR TITLE
Fix Ganesha binding when Manila is enabled

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -87,7 +87,7 @@
         standalone_extra_config: "{{ standalone_extra_config | combine(manila_extra_config) }}"
       vars:
         manila_extra_config:
-          ganesha_vip: "{{ public_api }}"
+          ganesha_vip: "{{ control_plane_ip }}"
 
     - name: Ensure ceph is enabled
       set_fact:


### PR DESCRIPTION
We need to bind Ganesha to the control plane or the NFS mounts are not
binding on the control plane, and then the client will try to use the
public IP to mount, and it's wrong.

Tested against a real environment.
