### PR TITLE
Download CIP from upstream/master if cip_config not defined on CentOS

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -126,8 +126,11 @@
           octavia_env:
             - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
 
+  # On RHEL/OSP if cip_config is not provided, we download it from latest puddle
   - name: Set cip_config from downloaded container_image_prepare.yaml
-    when: cip_config is not defined
+    when:
+      - cip_config is not defined
+      - ansible_facts.distribution == 'RedHat'
     block:
     - name: Read container_image_prepare.yaml
       slurp:
@@ -146,7 +149,8 @@
         keys: "{{ cip_raw | map(attribute='key') | map('regex_replace', '-', '_') | list }}"
         values: "{{ cip_raw | map(attribute='value') | list }}"
 
-  - name: Create containers-prepare-parameters.yaml
+  - name: Create containers-prepare-parameters.yaml if cip_config is defined
+    when: cip_config is defined
     copy:
       dest: "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
       content: "{{ cip_content | to_nice_yaml }}"
@@ -156,6 +160,16 @@
       cip_content:
         parameter_defaults:
           ContainerImagePrepare: "{{ cip_config }}"
+
+  - name: Download containers-prepare-parameters.yaml from upstream master if cip_config is not defined on CentOS
+    when:
+      - cip_config is not defined
+      - ansible_facts.distribution == 'CentOS'
+    get_url:
+      dest: "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
+      url: "https://opendev.org/openstack/tripleo-common/raw/branch/master/container-images/container_image_prepare_defaults.yaml"
+      owner: stack
+      mode: 0644
 
   - name: Add ceph to enabled services
     set_fact:

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -101,3 +101,8 @@ sriov_services:
 #dpdk_kernel_args:
 #dpdk_isol_cpus_list:
 #dpdk_cpu_shared_set:
+
+# This should not be changed unless you know what you're doing
+# because CentOS8 stream is now the only distro supported when deploying
+# TripleO from upstream.
+tripleo_repos_stream: true


### PR DESCRIPTION
We already have safe defaults on RHEL/OSP for cip_config, where if it's
not defined we download the CIP from internal puddles and it's fine.

However when deploying on CentOS, we don't have safe defaults, so let's
add safe defaults which are:

* using CIP from tripleo-common master
* tripleo_repos_stream set to True
