### PR TITLE
Bug 1960710: Revert "Automate manila share type creation"

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -111,15 +111,6 @@
     environment:
       OS_CLOUD: standalone
 
-  - name: Create Manila share type for CephFS NFS # noqa 301
-    shell: |
-      if ! openstack share type show cephfsnfstype; then
-          openstack share type create cephfsnfstype false
-      fi
-    when: manila_enabled
-    environment:
-      OS_CLOUD: standalone
-
   - name: Read clouds.yaml
     slurp:
       src: &cloudsyamlpath /home/stack/.config/openstack/clouds.yaml


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1960710

```
[stack@foch ~]$ rpm -qa|grep manilaclient
python3-manilaclient-2.6.0-0.20210323054047.1075210.el8.noarch
[stack@foch ~]$ openstack share type create cephfsnfstype false
Version 2.63 is not supported by the API. Minimum is 2.0 and maximum is 2.60. (HTTP 406) (Request-ID: req-cb62d943-ea63-4cd2-b3d9-5130bb3b0e1a)```

It doesn't work, it seems that the version of manilaclient is too recent for Manila, when running from the standalone host on master. Let's just revert that for now and re-implement later when packaging is correct.