### PR TITLE
Manila: re-enable share create

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -119,6 +119,8 @@
     when: manila_enabled
     environment:
       OS_CLOUD: standalone
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1960710
+      OS_SHARE_API_VERSION: 2.60
 
   - name: Read clouds.yaml
     slurp:

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -111,6 +111,15 @@
     environment:
       OS_CLOUD: standalone
 
+  - name: Create Manila share type for CephFS NFS # noqa 301
+    shell: |
+      if ! openstack share type show cephfsnfstype; then
+          openstack share type create cephfsnfstype false
+      fi
+    when: manila_enabled
+    environment:
+      OS_CLOUD: standalone
+
   - name: Read clouds.yaml
     slurp:
       src: &cloudsyamlpath /home/stack/.config/openstack/clouds.yaml

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -114,7 +114,7 @@
   - name: Create Manila share type for CephFS NFS # noqa 301
     shell: |
       if ! openstack share type show cephfsnfstype; then
-          openstack share type create cephfsnfstype false
+          openstack share type create --snapshot-support false cephfsnfstype false
       fi
     when: manila_enabled
     environment:


### PR DESCRIPTION
- Revert "Revert "Automate manila share type creation""
- manila: force OS_SHARE_API_VERSION to 2.60 - context is explained in BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1960710
