### PR TITLE
Allow to override openshift password in Keystone

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -19,7 +19,7 @@
           openstack project create openshift
       fi
       if ! openstack user show openshift; then
-          openstack user create --password 'password' openshift
+          openstack user create --password '{{ openshift_password }}' openshift
       fi
       for r in _member_ member swiftoperator; do
           if openstack role show $r; then

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -7,6 +7,9 @@ clouddomain: shiftstack
 # called `standalone`.
 local_cloudname: standalone
 
+# Keystone password for the 'openshift' user
+openshift_password: password
+
 # The control plane IP address allocated to br-ctlplane
 # You probably won't need to change this
 control_plane_ip: 192.168.24.1


### PR DESCRIPTION
For security purposes, it can be useful to override the default
password "password" that was set before with something more secure.
