### PR TITLE
Makefile: force the shell to be bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@
 #
 # It is recommended to run:
 #   make config host=<myhost>
+#
+SHELL=/bin/bash
+
 host ?= my_osp_host
 user ?= root
 ansible_args ?=


### PR DESCRIPTION
Not every system runs bash by default (e.g. systems provided by Github
CI), so if we want the commands to run fine (e.g. `echo -e`) we need to
force the SHELL to be bash.
