### PR TITLE
Enable TripleO HA services by default

### DIFF
--- a/example-overrides/local-overrides-centos8-tripleo-train.yaml
+++ b/example-overrides/local-overrides-centos8-tripleo-train.yaml
@@ -1,7 +1,5 @@
 standalone_host: <standalone FQDN>
-# Both public_api and control_plane_ip have to be the same in OSP16 for Pacemaker
 public_api: <IP address used to reach the node>
-control_plane_ip: <Same IP address used to reach the node>
 tripleo_repos_branch: train
 cip_config:
   - set:

--- a/example-overrides/local-overrides-osp16-2.yaml
+++ b/example-overrides/local-overrides-osp16-2.yaml
@@ -1,6 +1,4 @@
 standalone_host: <standalone FQDN>
-# Both public_api and control_plane_ip have to be the same in OSP16 for Pacemaker
 public_api: <IP address used to reach the node>
-control_plane_ip: <Same IP address used to reach the node>
 # Get latest 16.2 puddle
 rhos_release: 16.2

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -17,6 +17,17 @@
     set_fact:
       service_envs: "{{ enabled_services }}"
 
+  # OSP16 doesn't have HA enabled by default for all service (HAproxy).
+  # While this is being fixed, we'll force it here.
+  - name: Enable HA by default
+    block:
+    - name: Add HA services
+      set_fact:
+        service_envs: "{{ service_envs | union(ha_env) }}"
+      vars:
+        ha_env:
+        - /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml
+
   - name: Install the tripleo client
     yum:
       name:


### PR DESCRIPTION
In OSP16, HAproxy isn't deployed with Pacemaker by default which
apparently can cause issues if the public IP is the same as the control
plane IP.

To counter that, we simply need to turn the services that can be HA to
be deployed by Pacemaker.

Also, it removes the need of having the control plan IP to be the same
as the public IP.
