### PR TITLE
Enable SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,6 @@ This will configure your local clouds.yaml with 2 entries:
 You can change the name of these entries by editing `local-overrides.yaml` and
 setting `local_cloudname` to something else.
 
-If SSL is enabled, the CA will be pulled from the host and deployed in PKI.
-
 ## Network configuration
 
 dev-install will create a new OVS bridge called br-ex and move the host's
@@ -133,3 +131,16 @@ couldn't be automatically set for you by dev-install.
 | `dpdk_kernel_args` | `[undefined]` | Kernel arguments to configure when booting the machine. |
 | `dpdk_isol_cpus_list` | `[undefined]` | A set of CPU cores isolated from the host processes represented via a comma-separated list or range of physical host CPU numbers to which processes for pinned instance CPUs can be scheduled.
 | `dpdk_cpu_shared_set` | `[undefined]` | A comma-separated list or range of physical host CPU numbers used to determine the host CPUs for instance emulator threads.
+
+### SSL for public endpoints
+
+This sections contains configuration procedures for enabling SSL on OpenStack public endpoints.
+
+| Name              | Default Value       | Description          |
+|-------------------|---------------------|----------------------|
+| `ssl_enabled` | `false` | Whether or not we enable SSL for public endpoints |
+| `ssl_ca_cert` | `[undefined]` | CA certificate. If undefined, a self-signed will be generated and deployed |
+| `ssl_key` | `[undefined]` | SSL Key. If undefined, it will be generated and deployed |
+| `ssl_cert` | `[undefined]` | SSL certificate. If undefined, a self-signed will be generated and deployed |
+| `ssl_ca_cert_path` | `/etc/pki/ca-trust/source/anchors/simpleca.crt` | Path to the CA certificate |
+| `update_local_pki` | `false` | Whether or not we want to update the local PKI with the CA certificate |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ This will configure your local clouds.yaml with 2 entries:
 You can change the name of these entries by editing `local-overrides.yaml` and
 setting `local_cloudname` to something else.
 
+If SSL is enabled, the CA will be pulled from the host and deployed in PKI.
+
 ## Network configuration
 
 dev-install will create a new OVS bridge called br-ex and move the host's

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -28,6 +28,62 @@
         ha_env:
         - /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml
 
+  - name: Enable SSL
+    when: ssl_enabled
+    block:
+    - name: Add SSL service
+      set_fact:
+        service_envs: "{{ service_envs | union(ssl_env) }}"
+      vars:
+        ssl_env:
+        - /usr/share/openstack-tripleo-heat-templates/environments/ssl/tls-endpoints-public-ip.yaml
+        - /usr/share/openstack-tripleo-heat-templates/environments/ssl/enable-tls.yaml
+        - /usr/share/openstack-tripleo-heat-templates/environments/ssl/inject-trust-anchor.yaml
+
+  - name: Generate SSL self-signed certificate
+    when: ssl_enabled
+    include_role:
+      name: simpleca
+    vars:
+      cert_user: standalone
+      ca_dir: "{{ ansible_env.HOME }}/ssl/ca"
+      cert_dir: "{{ ansible_env.HOME }}/ssl"
+      cert_name: standalone
+
+  - name: Prepare the host for SSL
+    when: ssl_enabled
+    block:
+      - name: Read SSL certificate
+        slurp:
+          src: "{{ ansible_env.HOME }}/ssl/standalone.crt"
+        register: ssl_cert_output
+      - name: Read SSL key
+        slurp:
+          src: "{{ ansible_env.HOME }}/ssl/standalone.key"
+        register: ssl_key_output
+      - name: Read CA certificate
+        slurp:
+          src: "{{ ansible_env.HOME }}/ssl/ca/simpleca.crt"
+        register: ssl_ca_cert_output
+      - name: Set facts for SSL
+        set_fact:
+          ssl_cert: "{{ ssl_cert_output['content'] | b64decode }}"
+          ssl_key: "{{ ssl_key_output['content'] | b64decode }}"
+          ssl_ca_cert: "{{ ssl_ca_cert_output['content'] | b64decode }}"
+      - name: Copy CA cert into PKI
+        become: true
+        become_user: root
+        copy:
+          dest: "{{ ssl_ca_cert_path }}"
+          content: "{{ ssl_ca_cert }}"
+          mode: '0444'
+          owner: root
+          group: root
+      - name: Update CA trust
+        become: true
+        become_user: root
+        command: update-ca-trust extract
+
   - name: Install the tripleo client
     yum:
       name:
@@ -227,6 +283,8 @@
       tripleo_deploy_output_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_local_ip: "{{ public_api }}"
       tripleo_deploy_control_virtual_ip: "{{ control_plane_ip }}"
+      #TODO(emilien) figure out if we need this:
+      #tripleo_deploy_public_virtual_ip: "{{ ssl_enabled | ternary(public_api, omit) }}"
       tripleo_deploy_environment_files: "{{ default_tripleo_envs + service_envs + tripleo_override_envs }}"
       tripleo_deploy_generate_scripts: true
       tripleo_deploy_keep_running: true

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -52,6 +52,7 @@
 
   - name: Prepare the host for SSL
     when: ssl_enabled
+    no_log: true
     block:
       - name: Read SSL certificate
         slurp:
@@ -171,6 +172,7 @@
         ceph_enabled: true
 
   - name: Create standalone_parameters.yaml
+    no_log: true
     template:
       mode: 0644
       src: standalone_parameters.yaml.j2

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -57,18 +57,28 @@
         slurp:
           src: "{{ ansible_env.HOME }}/ssl/standalone.crt"
         register: ssl_cert_output
+        when: ssl_cert is not defined
       - name: Read SSL key
         slurp:
           src: "{{ ansible_env.HOME }}/ssl/standalone.key"
         register: ssl_key_output
+        when: ssl_ssl_key is not defined
       - name: Read CA certificate
         slurp:
           src: "{{ ansible_env.HOME }}/ssl/ca/simpleca.crt"
         register: ssl_ca_cert_output
-      - name: Set facts for SSL
+        when: ssl_ca_cert is not defined
+      - name: Set fact for SSL cert
+        when: ssl_cert is not defined
         set_fact:
           ssl_cert: "{{ ssl_cert_output['content'] | b64decode }}"
+      - name: Set fact for SSL key
+        when: ssl_key is not defined
+        set_fact:
           ssl_key: "{{ ssl_key_output['content'] | b64decode }}"
+      - name: Set fact for CA cert
+        when: ssl_ca_cert is not defined
+        set_fact:
           ssl_ca_cert: "{{ ssl_ca_cert_output['content'] | b64decode }}"
       - name: Copy CA cert into PKI
         become: true

--- a/playbooks/local_os_client.yaml
+++ b/playbooks/local_os_client.yaml
@@ -27,7 +27,7 @@
         set_fact:
           ssl_ca_cert: "{{ ssl_ca_cert_output['content'] | b64decode }}"
       - name: Copy CA cert into PKI
-        when: ssl_enabled
+        when: update_local_pki
         become: true
         become_user: root
         delegate_to: localhost
@@ -38,6 +38,7 @@
           owner: root
           group: root
       - name: Update CA trust
+        when: update_local_pki
         become: true
         become_user: root
         delegate_to: localhost

--- a/playbooks/local_os_client.yaml
+++ b/playbooks/local_os_client.yaml
@@ -16,6 +16,33 @@
     set_fact:
       cloudsyaml: "{{ cloudsyaml['content'] | b64decode | from_yaml }}"
 
+  - name: Grab the CA certificate
+    when: ssl_enabled
+    block:
+      - name: Read CA certificate
+        slurp:
+          src: "{{ ssl_ca_cert_path }}"
+        register: ssl_ca_cert_output
+      - name: Set fact for CA cert
+        set_fact:
+          ssl_ca_cert: "{{ ssl_ca_cert_output['content'] | b64decode }}"
+      - name: Copy CA cert into PKI
+        when: ssl_enabled
+        become: true
+        become_user: root
+        delegate_to: localhost
+        copy:
+          dest: "{{ ssl_ca_cert_path }}"
+          content: "{{ ssl_ca_cert }}"
+          mode: '0444'
+          owner: root
+          group: root
+      - name: Update CA trust
+        become: true
+        become_user: root
+        delegate_to: localhost
+        command: update-ca-trust extract
+
 - hosts: localhost
   gather_facts: false
   vars_files: vars/defaults.yaml

--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -1,5 +1,13 @@
 ---
 # With thanks to https://milliams.com/posts/2020/ansible-certificate-authority/
+
+- name: install crypto library for openssl_* modules
+  become: true
+  become_user: root
+  yum:
+    state: installed
+    name: python3-cryptography
+
 - name: Create the CA directory
   file:
     path: "{{ ca_dir }}"

--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -38,7 +38,11 @@
     path: "{{ cert_dir }}/{{ cert_user }}.csr"
     privatekey_path: "{{ user_key.filename }}"
     common_name: "{{ cert_name }}"
-    subject_alt_name: "DNS:{{ cert_name }}"
+    subject_alt_name:
+      - "DNS:{{ cert_name }}"
+      - "DNS:{{ standalone_host }}"
+      - "IP:{{ public_api }}"
+      - "IP:{{ control_plane_ip }}"
   register: user_csr
 
 - name: Sign the CSR for {{ cert_user }}

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -81,6 +81,17 @@ parameter_defaults:
   CephPoolDefaultPgNum: 8
   CephPoolDefaultSize: 1
 {% endif %}
+{% if ssl_enabled %}
+  AddVipsToEtcHosts: true
+  HorizonSecureCookies: True
+  SSLCertificate: |
+    {{ ssl_cert | indent }}
+  SSLKey: |
+    {{ ssl_key | indent }}
+  SSLRootCertificate: |
+    {{ ssl_ca_cert | indent }}
+  PublicTLSCAFile: {{ ssl_ca_cert_path }}
+{% endif %}
 {% if standalone_extra_config|length > 0 %}
   StandaloneExtraConfig:
 {% for key, value in standalone_extra_config.items() %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -95,9 +95,15 @@ octavia_enabled: true
 manila_enabled: false
 
 # Enable SSL for the OpenStack public endpoints
-# using self-signed certificate
 ssl_enabled: false
+# To use your own certificates and key, set these variables, otherwise
+# dev-install will generate self-signed certificates and use them
+# ssl_ca_cert
+# ssl_cert
+# ssl_key
 ssl_ca_cert_path: /etc/pki/ca-trust/source/anchors/simpleca.crt
+# Whether or not we update the local PKI with the CA certificate
+update_local_pki: false
 
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -94,6 +94,11 @@ octavia_enabled: true
 
 manila_enabled: false
 
+# Enable SSL for the OpenStack public endpoints
+# using self-signed certificate
+ssl_enabled: false
+ssl_ca_cert_path: /etc/pki/ca-trust/source/anchors/simpleca.crt
+
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent
   - OS::TripleO::Services::BootParams


### PR DESCRIPTION
By setting `ssl_enabled` to true, dev-install will do the following:

* Generate a CA, re-using what Matt did when doing `make certs`.
* Generate a private key, a certificate and sign with the CA.
* The certificate is signed to allow DNS and IP addresses, for
  control plane IP, public IP and the standalone_host, so the
  certificate will be usable for different kind of endpoints
  even though OpenStack TLS will be configured only with IP based
  endpoints for Public interface only.
* When running `make local_os_client`, it will pull the CA from the host
  on the local host so the client can use the OpenStack out of the box
  using SSL.

  This was manually tested with OSP 16.2.