### PR TITLE
Allow to configure authorized SSH keys for stack user

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -12,6 +12,14 @@
       name: stack
       groups: wheel
 
+  - name: Configure authorized SSH keys for stack user
+    when: (authorized_keys | length) > 1
+    ansible.posix.authorized_key:
+      user: stack
+      state: present
+      key: "{{ item }}"
+    loop: "{{ authorized_keys }}"
+
   - name: Prepare host on RHEL system
     when:
       - ansible_facts.distribution == 'RedHat'

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -109,3 +109,8 @@ sriov_services:
 # because CentOS8 stream is now the only distro supported when deploying
 # TripleO from upstream.
 tripleo_repos_stream: true
+
+# A list of SSH public keys that will be authorized to be used
+# when connecting with the stack user
+# They have to be URLs, e.g. https://github.com/foobar.keys
+authorized_keys: []


### PR DESCRIPTION
It can be handy when deploying & sharing environment among the team, to
pre-configure who will have access and dev-install will add the keys.
