### PR TITLE
Use current-tripleo by default

### DIFF
--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -78,7 +78,7 @@ neutron_bridge_mappings: "external:br-ex,hostonly:br-hostonly"
 neutron_flat_networks: "external,hostonly"
 
 tripleo_repos_repos:
-  - current-tripleo-dev
+  - current-tripleo
   - ceph
 
 ceph_enabled: true


### PR DESCRIPTION
Instead of current-tripleo-dev which is actual master, let's use
current-tripleo which is a repo that is tested, from master, so might
be lagging a bit but at least better tested.
