### PR TITLE
Support TripleO deployment from stable/train

### DIFF
--- a/example-overrides/local-overrides-centos8-tripleo-train.yaml
+++ b/example-overrides/local-overrides-centos8-tripleo-train.yaml
@@ -1,8 +1,11 @@
 standalone_host: <standalone FQDN>
 public_api: <IP address used to reach the node>
 tripleo_repos_branch: train
+# tripleo-repos only supports --stream (for CentOS 8 Stream) after Train,
+# so we need to pull tripleo-repos tool from master and move on.
+tripleo_repos_repo_branch: master
 cip_config:
   - set:
-      namespace: quay.io/tripleotrain
-      name_prefix: openstack-
+      namespace: quay.io/tripleotraincentos8
+      name_prefix: centos-binary-
       tag: current-tripleo

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -2,6 +2,7 @@
 
 parameter_defaults:
   CloudName: {{ hostname }}.{{ clouddomain }}
+  ContainerCli: podman
   Debug: true
   DeploymentUser: {{ ansible_env.USER }}
   DnsServers:


### PR DESCRIPTION
2 changes:

### Update example overrides
To help anyone who wants to deploy TripleO train, will be able to use the example.

### ContainerCli
When deploying TripleO upstream from stable/train, we need to override
the default ContainerCli to "podman" and not let "docker" since it's not
a thing anymore.

We kept it this way for backward compatibility in TripleO but in reality
when enabling HA on centos8 in Train, you need Podman.
