### PR TITLE
Support for RHSM

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -227,11 +227,19 @@
           octavia_env:
             - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
 
+  - name: Generate container_image_prepare.yaml if not using rhos-release
+    when:
+      - cip_config is not defined
+      - ansible_facts.distribution == 'RedHat'
+      - rhsm_enabled
+    command: openstack tripleo container image prepare default --output-env-file /home/stack/containers-prepare-parameters.yaml
+
   # On RHEL/OSP if cip_config is not provided, we download it from latest puddle
   - name: Set cip_config from downloaded container_image_prepare.yaml
     when:
       - cip_config is not defined
       - ansible_facts.distribution == 'RedHat'
+      - not rhsm_enabled
     block:
     - name: Read container_image_prepare.yaml
       slurp:

--- a/playbooks/local_requirements.yaml
+++ b/playbooks/local_requirements.yaml
@@ -2,5 +2,7 @@
   connection: local
   vars:
     update_operator: true
+    update_rhsm: true
   roles:
     - operators
+    - rhsm

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -20,9 +20,27 @@
       key: "{{ item }}"
     loop: "{{ authorized_keys }}"
 
-  - name: Prepare host on RHEL system
+  - name: Prepare host on RHEL system with Subscription Manager
     when:
       - ansible_facts.distribution == 'RedHat'
+      - rhsm_enabled
+    block:
+      - name: Configure Red Hat Subscription Manager
+        import_role:
+          name: redhat-subscription
+      - name: Install container-tools module
+        shell: |
+          dnf module disable -y container-tools:rhel8
+          dnf module enable -y container-tools:"{{ rhsm_container_tools_version }}"
+      - name: Install virt module
+        shell: |
+          dnf module disable -y virt:rhel
+          dnf module enable -y virt:"{{ rhsm_release }}"
+
+  - name: Prepare host on RHEL system with rhos-release
+    when:
+      - ansible_facts.distribution == 'RedHat'
+      - not rhsm_enabled
     block:
       - name: install rhos-release
         yum:

--- a/playbooks/roles/rhsm/tasks/main.yaml
+++ b/playbooks/roles/rhsm/tasks/main.yaml
@@ -1,0 +1,16 @@
+---
+- name: Ensure we have ~/.ansible
+  tags:
+    - always
+    - lab
+  file:
+    mode: 0755
+    path: ~/.ansible/roles
+    state: directory
+
+- name: Clone ansible-role-redhat-subscription
+  git:
+    dest: ~/.ansible/roles/redhat-subscription
+    repo: https://opendev.org/openstack/ansible-role-redhat-subscription
+    update: "{{ update_rhsm | bool }}"
+    version: master

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -81,6 +81,12 @@ parameter_defaults:
   CephPoolDefaultPgNum: 8
   CephPoolDefaultSize: 1
 {% endif %}
+{% if rhsm_enabled %}
+  ContainerImageRegistryCredentials:
+    registry.redhat.io:
+      {{ redhat_registry_credentials | mandatory }}
+  ContainerImageRegistryLogin: true
+{% endif %}
 {% if ssl_enabled %}
   AddVipsToEtcHosts: true
   HorizonSecureCookies: True

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -129,3 +129,21 @@ tripleo_repos_stream: true
 # when connecting with the stack user
 # They have to be URLs, e.g. https://github.com/foobar.keys
 authorized_keys: []
+
+# Red Hat Subscription Manager options
+rhsm_enabled: false
+rhsm_repos:
+  - rhel-8-for-x86_64-baseos-eus-rpms
+  - rhel-8-for-x86_64-appstream-eus-rpms
+  - rhel-8-for-x86_64-highavailability-eus-rpms
+  - ansible-2.9-for-rhel-8-x86_64-rpms
+  - openstack-16.1-for-rhel-8-x86_64-rpms
+  - fast-datapath-for-rhel-8-x86_64-rpms
+  - advanced-virt-for-rhel-8-x86_64-rpms
+  - rhceph-4-osd-for-rhel-8-x86_64-rpms
+  - rhceph-4-tools-for-rhel-8-x86_64-rpms
+rhsm_method: "portal"
+rhsm_release: 8.2
+rhsm_container_tools_version: '2.0'
+# Red Hat Registry credentials have to be set when deploying OSP on RHEL
+# redhat_registry_credentials


### PR DESCRIPTION
When we want to deploy Red Hat OpenStack as customers would do, using
the product, we don't want to use the internal puddle (rhos-release).
For that we need to use Red Hat Subscription Manager (RHSM) which has
its Ansible role.

This patch will:

* deploy the role in ~/.ansible/roles
* provide safe defaults for OSP 16.1 (latest release)
* call the role when rhsm_enabled is set to True
* manage required modules
* generate CIP config using CLI
* login to the containe registry when deploying

More information about the role:
https://docs.openstack.org/project-deploy-guide/tripleo-docs/latest/features/rhsm.html