### PR TITLE
Make ceph vg creation idempotent

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -130,14 +130,10 @@
           - util-linux
           - lvm2
         state: present
-    - name: Use dd and losetup to create the loop devices
-      shell: |
-        fallocate -l {{ ceph_loop_device_size }}G /var/lib/ceph-osd.img
-        losetup /dev/loop1 /var/lib/ceph-osd.img
-        pvcreate /dev/loop1
-        vgcreate vg2 /dev/loop1
-        lvcreate -n data-lv2 --size {{ ceph_loop_device_size * 96 / 100 }}G vg2
-        lvcreate -n db-lv2 --size {{ (ceph_loop_device_size * 4 / 100) - 0.1 }}G vg2
+    - name: Create a backing file for ceph
+      command: /usr/bin/fallocate -l {{ ceph_loop_device_size }}G /var/lib/ceph-osd.img
+      args:
+        creates: /var/lib/ceph-osd.img
     - name: Create /etc/systemd/system/ceph-osd-losetup.service
       copy:
         dest: /etc/systemd/system/ceph-osd-losetup.service
@@ -148,13 +144,29 @@
           After=syslog.target
           [Service]
           Type=oneshot
-          ExecStart=/bin/bash -c '/sbin/losetup /dev/loop1 || \
-          /sbin/losetup /dev/loop1 /var/lib/ceph-osd.img ; partprobe /dev/loop1'
+          ExecStart=/bin/bash -c '/sbin/losetup /dev/loop1 || /sbin/losetup --direct-io=on /dev/loop1 /var/lib/ceph-osd.img'
           ExecStop=/sbin/losetup -d /dev/loop1
           RemainAfterExit=yes
           [Install]
           WantedBy=multi-user.target
+      register: create_losetup_service
     - name: Enable ceph-osd-losetup.service
       systemd:
         name: ceph-osd-losetup.service
         enabled: true
+        state: "{{ create_losetup_service.changed | ternary('restarted', 'started') }}"
+        daemon_reload: "{{ create_losetup_service.changed }}"
+    - name: Create volume group for ceph
+      lvg:
+        vg: vg_ceph
+        pvs: /dev/loop1
+    - name: Create ceph data LV
+      lvol:
+        vg: vg_ceph
+        lv: data
+        size: 96%VG
+    - name: Create ceph db LV
+      lvol:
+        vg: vg_ceph
+        lv: db
+        size: 4%VG

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -63,10 +63,10 @@ parameter_defaults:
     osd_scenario: lvm
     osd_objectstore: bluestore
     lvm_volumes:
-      - data: data-lv2
-        data_vg: vg2
-        db: db-lv2
-        db_vg: vg2
+      - data: data
+        data_vg: vg_ceph
+        db: db
+        db_vg: vg_ceph
   # Since we use a loop device for Ceph disk, performances wouldn't be great enough
   # to boot VMs with heavy workloads on it.
   # This can be overriden by setting:


### PR DESCRIPTION
* Split out creation task into multiple tasks
* Use direct io on loopback device
* Only ever create loopback device with systemd unit
* Use ansible modules for vg/lv creation
* Rename created volume group to vg_ceph