### PR TITLE
Disable interfaces which aren't in use

### DIFF
--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -32,27 +32,57 @@
       enabled: true
       state: started
 
+  - name: Define dummy interfaces to be created
+    set_fact:
+      nmstate_ifs:
+      - name: dummy0
+        type: dummy
+        state: up
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+      - name: dummy1
+        type: dummy
+        state: up
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+
+  - name: Construct a list of disabled nics
+    set_fact:
+      disabled_nics: "{{ network_devices | difference(sriov_vfs) | difference(used_devices) }}"
+    vars:
+      used_devices: "{{ [ network_info.public_ipv4.interface ] + (sriov_interface is defined | ternary([sriov_interface], [])) }}"
+
+
+  - name: Disable interfaces which aren't in use
+    set_fact:
+      nmstate_ifs: "{{ nmstate_ifs + [ {'name': item} | combine(removed) ] }}"
+    loop: "{{ disabled_nics }}"
+    vars:
+      removed:
+        state: absent
+
+  - name: Disable DHCP on SR-IOV PFs
+    set_fact:
+      nmstate_ifs: "{{ nmstate_ifs + [ {'name': item} | combine(nodhcp) ] }}"
+    loop: "{{ sriov_pfs | difference(disabled_nics) }}"
+    vars:
+      nodhcp:
+        ipv4:
+          enabled: false
+        ipv6:
+          enabled: false
+
   - name: Set nmstate # noqa 301
     command: nmstatectl set --no-commit --timeout 60
     args:
       stdin: "{{ network_state | to_nice_json }}"
     vars:
       network_state:
-        interfaces:
-        - name: dummy0
-          type: dummy
-          state: up
-          ipv4:
-            enabled: false
-          ipv6:
-            enabled: false
-        - name: dummy1
-          type: dummy
-          state: up
-          ipv4:
-            enabled: false
-          ipv6:
-            enabled: false
+        interfaces: "{{ nmstate_ifs }}"
     register: nmstateset
 
   # Doing this in 2 steps means that we'll automatically rollback if we break
@@ -61,6 +91,13 @@
     command: nmstatectl commit "{{ checkpoint }}"
     vars:
       checkpoint: "{{ (nmstateset.stdout_lines|last).split()[1] }}"
+
+  # This prevents OpenStack installation failure later if the network unit
+  # failed because not all physical interfaces have DHCP
+  - name: Ensure network systemd unit is up
+    systemd:
+      name: network
+      state: started
 
   - name: Create systemd unit to add SNAT rule for hostonly network
     template:

--- a/playbooks/roles/network_info/tasks/main.yaml
+++ b/playbooks/roles/network_info/tasks/main.yaml
@@ -34,3 +34,59 @@
       content: "{{ network_info | to_nice_json }}"
       mode: 0755
   when: networkinfo_file.failed
+
+- name: Find network devices with a device link
+  find:
+    paths: /sys/class/net
+    patterns:
+    - device
+    file_type: link
+    follow: true
+    depth: 2
+    recurse: true
+    use_regex: false
+  register: device_links
+
+- name: Extract paths from device_links
+  set_fact:
+    device_links: "{{ device_links.files | map(attribute='path') | list }}"
+
+- name: Extract device names from device_links
+  set_fact:
+    network_devices: "{{ network_devices + [ item | dirname | basename ] }}"
+  loop: "{{ device_links }}"
+  vars:
+    network_devices: []
+
+- name: Initialise SR-IOV PFs to an empty list
+  set_fact:
+    sriov_pfs: []
+
+- name: Find SR-IOV PFs
+  find:
+    paths: "{{ device_links }}"
+    patterns:
+    - sriov_totalvfs
+  register: sriov_totalvfs
+
+- name: Extract device names for SR-IOV PFs
+  set_fact:
+    sriov_pfs: "{{ sriov_pfs + [ item | dirname | dirname | basename ] }}"
+  loop: "{{ sriov_totalvfs.files | map(attribute='path') | list }}"
+
+- name: Initialise SR-IOV VFs to an empty list
+  set_fact:
+    sriov_vfs: []
+
+- name: Find SR-IOV VFs
+  find:
+    paths: "{{ device_links }}"
+    patterns:
+    - physfn
+    file_type: link
+  register: sriov_physfndir
+
+- name: Extract device names for SR-IOV VFs
+  set_fact:
+    sriov_vfs: "{{ sriov_vfs + [ item | dirname | dirname | basename ] }}"
+  loop: "{{ sriov_physfndir.files | map(attribute='path') | list }}"


### PR DESCRIPTION
I can't install without this patch. deploy always fails with TripleO complaining that the network service failed.

Bonus: this patch auto-detects SR-IOV devices. We can use that to improve SR-IOV support.