### PR TITLE
validations: remove standalone role validation

### DIFF
--- a/playbooks/validations.yaml
+++ b/playbooks/validations.yaml
@@ -23,9 +23,3 @@
           You must set different IP addresses for control_plane_ip and public_api otherwise
           the deployment of OpenStack will fail.
         success_msg: 'control plane IP is different from the public IP'
-
-    - name: Check that Standalone role file exists
-      stat:
-        path: "{{ standalone_role }}"
-      register: standalone_role_stat_result
-      failed_when: not standalone_role_stat_result.stat.exists


### PR DESCRIPTION
The file can't exist if the node wasn't provisioned, since it requires
the rpms to be installed.

Let's just remove that validation which was wrongly added.
