### PR TITLE
SSL: "Bring your own CA" support & generate SSL locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ This sections contains configuration procedures for enabling SSL on OpenStack pu
 |-------------------|---------------------|----------------------|
 | `ssl_enabled` | `false` | Whether or not we enable SSL for public endpoints |
 | `ssl_ca_cert` | `[undefined]` | CA certificate. If undefined, a self-signed will be generated and deployed |
+| `ssl_ca_key` | `[undefined]` | CA key. If undefined, it will be generated and used to sign the SSL certificate |
 | `ssl_key` | `[undefined]` | SSL Key. If undefined, it will be generated and deployed |
 | `ssl_cert` | `[undefined]` | SSL certificate. If undefined, a self-signed will be generated and deployed |
 | `ssl_ca_cert_path` | `/etc/pki/ca-trust/source/anchors/simpleca.crt` | Path to the CA certificate |

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -40,35 +40,57 @@
         - /usr/share/openstack-tripleo-heat-templates/environments/ssl/enable-tls.yaml
         - /usr/share/openstack-tripleo-heat-templates/environments/ssl/inject-trust-anchor.yaml
 
-  - name: Generate SSL self-signed certificate
+  - name: Generate SSL self-signed certificate on localhost
     when: ssl_enabled
-    include_role:
-      name: simpleca
-    vars:
-      cert_user: standalone
-      ca_dir: "{{ ansible_env.HOME }}/ssl/ca"
-      cert_dir: "{{ ansible_env.HOME }}/ssl"
-      cert_name: standalone
+    become: false
+    # We run this block on localhost because we don't want to put the CA key on the remote
+    # server, which could lead to security problems.
+    delegate_to: localhost
+    block:
+    - name: Create temporary directory for SSL files
+      tempfile:
+        state: directory
+        suffix: dev-install-ssl
+      register: ssl_dir
+    - name: Generate SSL self-signed certificate
+      include_role:
+        name: simpleca
+      vars:
+        cert_user: standalone
+        ca_dir: "{{ ssl_dir.path }}/ssl/ca"
+        cert_dir: "{{ ssl_dir.path }}/ssl"
+        cert_name: standalone
 
   - name: Prepare the host for SSL
     when: ssl_enabled
     no_log: true
     block:
-      - name: Read SSL certificate
-        slurp:
-          src: "{{ ansible_env.HOME }}/ssl/standalone.crt"
-        register: ssl_cert_output
-        when: ssl_cert is not defined
-      - name: Read SSL key
-        slurp:
-          src: "{{ ansible_env.HOME }}/ssl/standalone.key"
-        register: ssl_key_output
-        when: ssl_key is not defined
-      - name: Read CA certificate
-        slurp:
-          src: "{{ ansible_env.HOME }}/ssl/ca/simpleca.crt"
-        register: ssl_ca_cert_output
-        when: ssl_ca_cert is not defined
+      - name: Read and clean SSL files
+        become: false
+        delegate_to: localhost
+        block:
+          - name: Read SSL certificate
+            slurp:
+              src: "{{ ssl_dir.path }}/ssl/standalone.crt"
+            register: ssl_cert_output
+            when: ssl_cert is not defined
+          - name: Read SSL key
+            slurp:
+              src: "{{ ssl_dir.path }}/ssl/standalone.key"
+            register: ssl_key_output
+            when: ssl_key is not defined
+          - name: Read CA certificate
+            slurp:
+              src: "{{ ssl_dir.path }}/ssl/ca/simpleca.crt"
+            register: ssl_ca_cert_output
+            when: ssl_ca_cert is not defined
+          # At this point the files should not be useful, so we can
+          # clear them to avoid any leak on the host where Ansible
+          # is run.
+          - name: Remove temporary directory for SSL files
+            file:
+              state: absent
+              path: "{{ ssl_dir.path }}"
       - name: Set fact for SSL cert
         when: ssl_cert is not defined
         set_fact:

--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -14,27 +14,55 @@
     state: directory
     mode: '0750'
 
-- name: Create CA key
-  openssl_privatekey:
-    path: "{{ ca_dir }}/simpleca.key"
-  register: ca_key
+- name: Run the tasks to create CA cert and key when not provided
+  when: ssl_ca_cert is not defined or ssl_ca_key is not defined
+  block:
+    - name: Create CA key
+      openssl_privatekey:
+        path: "{{ ca_dir }}/simpleca.key"
+      register: ca_key
 
-- name: Create the CA CSR
-  openssl_csr:
-    path: "{{ ca_dir }}/simpleca.csr"
-    privatekey_path: "{{ ca_key.filename }}"
-    common_name: "simpleca"
-    basic_constraints:
-    - "CA:TRUE"
-  register: ca_csr
+    - name: Create the CA CSR
+      openssl_csr:
+        path: "{{ ca_dir }}/simpleca.csr"
+        privatekey_path: "{{ ca_key.filename }}"
+        common_name: "simpleca"
+        basic_constraints:
+        - "CA:TRUE"
+      register: ca_csr
 
-- name: Sign the CA CSR
-  openssl_certificate:
-    path: "{{ ca_dir }}/simpleca.crt"
-    csr_path: "{{ ca_csr.filename }}"
-    privatekey_path: "{{ ca_key.filename }}"
-    provider: selfsigned
-  register: ca_crt
+    - name: Sign the CA CSR
+      openssl_certificate:
+        path: "{{ ca_dir }}/simpleca.crt"
+        csr_path: "{{ ca_csr.filename }}"
+        privatekey_path: "{{ ca_key.filename }}"
+        provider: selfsigned
+      register: ca_crt
+
+    - name: Create facts for CA files
+      set_fact:
+        ca_crt_path: "{{ ca_crt.filename }}"
+        ca_key_path: "{{ ca_key.filename }}"
+
+- name: Run the tasks to create temp files for CA cert and key when provided
+  when: ssl_ca_cert is defined or ssl_ca_key is defined
+  block:
+    - name: "Write the CA cert into {{ ca_dir }}"
+      copy:
+        content: "{{ ssl_ca_cert | mandatory }}"
+        dest: "{{ ca_dir }}/simpleca.crt"
+        mode: 0400
+
+    - name: "Write the CA key into {{ ca_dir }}"
+      copy:
+        content: "{{ ssl_ca_key | mandatory }}"
+        dest: "{{ ca_dir }}/simpleca.key"
+        mode: 0400
+
+    - name: Create facts for CA files
+      set_fact:
+        ca_crt_path: "{{ ca_dir }}/simpleca.crt"
+        ca_key_path: "{{ ca_dir }}/simpleca.key"
 
 - name: Create a private key for {{ cert_user }}
   openssl_privatekey:
@@ -58,5 +86,5 @@
     path: "{{ cert_dir }}/{{ cert_user }}.crt"
     csr_path: "{{ user_csr.filename }}"
     provider: ownca
-    ownca_path: "{{ ca_crt.filename }}"
-    ownca_privatekey_path: "{{ ca_key.filename }}"
+    ownca_path: "{{ ca_crt_path }}"
+    ownca_privatekey_path: "{{ ca_key_path }}"

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -102,7 +102,7 @@ ssl_enabled: false
 # ssl_key
 # If you already have your own CA, you can provide these two variables
 # and dev-install will sign the certificates with it.
-# If left unset, dev-install will generate the CA ans self-sign it.
+# If left unset, dev-install will generate the CA and self-sign it.
 # ssl_ca_cert
 # ssl_ca_key
 ssl_ca_cert_path: /etc/pki/ca-trust/source/anchors/simpleca.crt

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -98,9 +98,13 @@ manila_enabled: false
 ssl_enabled: false
 # To use your own certificates and key, set these variables, otherwise
 # dev-install will generate self-signed certificates and use them
-# ssl_ca_cert
 # ssl_cert
 # ssl_key
+# If you already have your own CA, you can provide these two variables
+# and dev-install will sign the certificates with it.
+# If left unset, dev-install will generate the CA ans self-sign it.
+# ssl_ca_cert
+# ssl_ca_key
 ssl_ca_cert_path: /etc/pki/ca-trust/source/anchors/simpleca.crt
 # Whether or not we update the local PKI with the CA certificate
 update_local_pki: false


### PR DESCRIPTION
# Bring your own CA
Allow a user to bring their own Certificate Authority to dev-install,
so when OpenStack will be deployed, the generated certificate will be
signed with this CA.

It's a famous customer use-case, and will also be used by our CI, so we
can rely on a stable CA and just generate ephemeral certificates when
deploying OpenStack.

# Generate SSL files locally instead of remotely

Instead of generating all SSL files remotely, do it locally, it's more
secure.

The main reason of doing this is because we do not want the CA private
key to be on the remote host, this would be a security issue in case
someone has access to the host, they can compromise our CA