### PR TITLE
UX improvements for security

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ $(overrides):
 #
 
 .PHONY: osp_full
-osp_full: local_requirements prepare_host network install_stack prepare_stack
+osp_full: local_requirements prepare_host network install_stack prepare_stack local_os_client
 
 .PHONY: local_requirements
 local_requirements: inventory.yaml $(overrides)

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -95,7 +95,7 @@ octavia_enabled: true
 manila_enabled: false
 
 # Enable SSL for the OpenStack public endpoints
-ssl_enabled: false
+ssl_enabled: true
 # To use your own certificates and key, set these variables, otherwise
 # dev-install will generate self-signed certificates and use them
 # ssl_cert


### PR DESCRIPTION
## Add local_os_client to osp_full
When installing a cloud, it makes sense to run `local_os_client` by
default so the user can operate the OpenStack cloud immediately.

## Enable SSL by default
To improve the user experience, we enable SSL by default, with
self-signed CA & certificates, so the public endpoints are secure by
default.