### PR TITLE
Separate control plane & public endpoints networks

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -17,6 +17,13 @@
     set_fact:
       service_envs: "{{ enabled_services }}"
 
+  - name: Add external network VIP service
+    set_fact:
+      service_envs: "{{ service_envs | union(vip_env) }}"
+    vars:
+      vip_env:
+      - /usr/share/openstack-tripleo-heat-templates/environments/external-network-vip.yaml
+
   # OSP16 doesn't have HA enabled by default for all service (HAproxy).
   # While this is being fixed, we'll force it here.
   - name: Enable HA by default
@@ -315,6 +322,18 @@
       tripleo_override_envs:
         - "{{ ansible_env.HOME }}/standalone_parameters.yaml"
 
+  # Until https://review.opendev.org/c/openstack/tripleo-heat-templates/+/793836
+  # is merged upstream.
+  - name: Create the VIP env file
+    copy:
+      dest: /usr/share/openstack-tripleo-heat-templates/environments/external-network-vip.yaml
+      content: |
+        resource_registry:
+          OS::TripleO::Network::Ports::ExternalVipPort: ../network/ports/external_from_pool.yaml
+      mode: 0644
+    become: true
+    become_user: root
+
   - name: Run TripleO deploy
     import_role:
       name: tripleo.operator.tripleo_deploy
@@ -323,15 +342,15 @@
       tripleo_deploy_deployment_user: stack
       tripleo_deploy_standalone: true
       tripleo_deploy_output_dir: "{{ ansible_env.HOME }}"
-      tripleo_deploy_local_ip: "{{ public_api }}"
+      tripleo_deploy_local_ip: "{{ local_ip }}"
       tripleo_deploy_control_virtual_ip: "{{ control_plane_ip }}"
-      #TODO(emilien) figure out if we need this:
-      #tripleo_deploy_public_virtual_ip: "{{ ssl_enabled | ternary(public_api, omit) }}"
+      tripleo_deploy_public_virtual_ip: "{{ public_api }}"
       tripleo_deploy_environment_files: "{{ default_tripleo_envs + service_envs + tripleo_override_envs }}"
       tripleo_deploy_generate_scripts: true
       tripleo_deploy_keep_running: true
       tripleo_deploy_home_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_roles_file: "{{ ansible_env.HOME }}/tripleo_standalone_role.yaml"
+      tripleo_deploy_networks_file: /usr/share/openstack-tripleo-heat-templates/network_data_undercloud.yaml
 
   - name: Reboot if SR-IOV is enabled (to apply kernel changes)
     when:

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -21,7 +21,7 @@ network_config:
   ovs_extra:
   - br-set-external-id br-ctlplane bridge-id br-ctlplane
   addresses:
-  - ip_netmask: {{ control_plane_ip }}/32
+  - ip_netmask: {{ local_ip }}/{{ control_plane_prefix }}
   members:
   - type: interface
     name: dummy0

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -76,8 +76,8 @@ parameter_defaults:
   NovaEnableRbdBackend: false
 {% endif %}
   CephAnsibleExtraConfig:
-    cluster_network: {{ network_info.public_ipv4.network }}/{{ network_info.public_ipv4_cidr }}
-    public_network: {{ network_info.public_ipv4.network }}/{{ network_info.public_ipv4_cidr }}
+    cluster_network: {{ control_plane_cidr }}
+    public_network: {{ control_plane_cidr }}
   CephPoolDefaultPgNum: 8
   CephPoolDefaultSize: 1
 {% endif %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -10,9 +10,17 @@ local_cloudname: standalone
 # Keystone password for the 'openshift' user
 openshift_password: password
 
-# The control plane IP address allocated to br-ctlplane
-# You probably won't need to change this
-control_plane_ip: 192.168.24.1
+# Control plane network is used for services not exposed on the public network
+# and isolated under the br-ctlplane bridge.
+# * local_ip is the IP where the services actually listen to.
+# * control_plane_ip is the VIP that will be managed by Pacemaker,
+#   where HAproxy will listen on the control plane network and
+#   redirect the traffic to local_ip where the service actually listens.
+# You probably won't need to change this.
+control_plane_cidr: 192.168.24.0/24
+control_plane_prefix: "{{ control_plane_cidr | ipaddr('prefix') }}"
+local_ip: "{{ control_plane_cidr | nthhost(1) }}"
+control_plane_ip: "{{ control_plane_cidr | nthhost(2) }}"
 
 # The IP address of the public openstack endpoints
 # By default we use the default IP of the host


### PR DESCRIPTION
It is more secure to keep internal/admin networks under a secured
control plane network, and use the public interface for the public
endpoints.

* We will create external-network-vip.yaml environment, until the
  upstream patch in THT will merge:
  https://review.opendev.org/c/openstack/tripleo-heat-templates/+/793836
  This environments helps to configure TripleO to use an external IP for
  the public VIP.

* Configure standalone to run with local_ip, control plane IP and public
  IP, and also load the network config that is done for Undercloud, this
  is fine since TripleO Undercloud already separates public & internal
  endpoints.

* Use 192.168.24.0/24 as default control plane network, keep first IP
  for the local IP and second IP for the control plane VIP.