### PR TITLE
Bridging improvements

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -26,7 +26,7 @@ network_config:
   - type: interface
     name: dummy0
     nm_controlled: true
-{% for ip in tunnel_remote_ips | default([]) %}
+{% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-ctlplane-{{ ip | to_uuid }}"
     tunnel_type: vxlan
@@ -46,7 +46,7 @@ network_config:
   - destination: {{ hostonly_cidr }}
     nexthop: {{ hostonly_gateway }}
   members:
-{% for ip in tunnel_remote_ips | default([]) %}
+{% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-hostonly-{{ ip | to_uuid }}"
     tunnel_type: vxlan

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -17,7 +17,7 @@ network_config:
 - type: ovs_bridge
   name: br-ctlplane
   use_dhcp: false
-  mtu: 1500
+  mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
   ovs_extra:
   - br-set-external-id br-ctlplane bridge-id br-ctlplane
   addresses:
@@ -37,7 +37,7 @@ network_config:
 - type: ovs_bridge
   name: br-hostonly
   use_dhcp: false
-  mtu: 1500
+  mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
   ovs_extra:
   - br-set-external-id br-hostonly bridge-id br-hostonly
   addresses:


### PR DESCRIPTION
- Switch bridge MTU to 1400 if tunnels are being used.
When using VXLAN tunnels between the bridges, it's important to set proper MTU because the
Ethernet frame is being encapsulated in `Ethernet + IP + UDP + Overlay Header`.
This means that the Maximum Transmission Unit for the underlay needs to be adjusted to something close to 1400.
Using 1400 is a safe number for now which should give up flexibility in
using IPv4 and IPv6 in the future.

- Remove default value for tunnel_remote_ips in template
The default value for tunnel_remote_ips is already sets in default vars,
we don't want to duplicate it in the template.
