### PR TITLE
Remove rhceph-4-osd-for-rhel-8-x86_64-rpms from default OSP repos

### DIFF
--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -152,7 +152,6 @@ rhsm_repos:
   - openstack-16.1-for-rhel-8-x86_64-rpms
   - fast-datapath-for-rhel-8-x86_64-rpms
   - advanced-virt-for-rhel-8-x86_64-rpms
-  - rhceph-4-osd-for-rhel-8-x86_64-rpms
   - rhceph-4-tools-for-rhel-8-x86_64-rpms
 rhsm_method: "portal"
 rhsm_release: 8.2


### PR DESCRIPTION
This shouldn't be needed because we pull ceph-ansible from
rhceph-4-tools-for-rhel-8-x86_64-rpms and then everything else is
containerized.

I'm removing it because the repo isn't available in some RHSM
subscriptions for some reason. I'll propose a revert if I find out that
this patch caused more pain.
