### PR TITLE
Workaround to make Manila working on OSP16.1

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -151,6 +151,10 @@
     set_fact:
       sriov_services_fact: "{{ sriov_interface|default(None)| ternary(sriov_services, []) }}"
 
+  - name: Set fact for Manila services overrides
+    set_fact:
+      manila_services_fact: "{{ manila_enabled | ternary(manila_services, []) }}"
+
   - name: Read the TripleO role
     slurp:
       src: "{{ standalone_role }}"
@@ -168,7 +172,7 @@
     set_fact:
       role_data: >
         {% set _ = new_role_data.0.__setitem__('ServicesDefault', new_role_data.0.ServicesDefault |
-        union(sriov_services_fact) | union(standalone_role_overrides)) %}
+        union(sriov_services_fact) | union(manila_services_fact) | union(standalone_role_overrides)) %}
         {{ new_role_data }}
 
   - name: Create the new role file

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -105,6 +105,9 @@ ceph_loop_device_size: 100
 octavia_enabled: true
 
 manila_enabled: false
+# Workaround for BZ#1969962
+manila_services:
+  - OS::TripleO::Services::CephNfs
 
 # Enable SSL for the OpenStack public endpoints
 ssl_enabled: true


### PR DESCRIPTION
We need to manually add the CephNfs to the registry because it's
missing in the Standalone role for OSP16.1, there is a missing backport
from upstream to downstream:
https://review.opendev.org/c/openstack/tripleo-heat-templates/+/773205/

While this is being fixed via BZ#1969962, let's add the service
ourselves, which won't hurt any deployment (even master) since the list
will simply merge if the service already exists (which is the case on
> 16.1).
