### PR TITLE
Don't configure CephClusterName on central node

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -141,8 +141,10 @@ parameter_defaults:
   GlanceBackendID: central
   GlanceEnabledImportMethods: web-download,copy-image
   GlanceStoreDescription: 'central rbd glance store'
-{% endif %}
+{% else %}
+  # BZ#1901143 and BZ#1903005
   CephClusterName: {{ dcn_az }}
+{% endif %}
   CinderStorageAvailabilityZone: {{ dcn_az }}
   NeutronDefaultAvailabilityZones: {{ dcn_az }}
   NovaComputeAvailabilityZone: {{ dcn_az }}


### PR DESCRIPTION
Due to BZ#1901143 and BZ#1903005, we can't override the Ceph cluster
name where Manila is deployed.

In the case of our Edge setup, we only deploy Manila on the central
site so let's skip this parameter there and configure only the AZ
nodes.
