### PR TITLE
Switch `yum` to `package` module

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -151,7 +151,7 @@
         command: update-ca-trust extract
 
   - name: Install the tripleo client
-    yum:
+    package:
       name:
       - ceph-ansible
       - python3-tripleoclient
@@ -330,7 +330,7 @@
     when: ceph_enabled
 
   - name: Install all tuned profiles if SR-IOV is enabled
-    yum:
+    package:
       name:
       - tuned-profiles-*
     become: true

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -10,7 +10,7 @@
   tasks:
 
   - name: Install ovs tools
-    yum:
+    package:
       state: installed
       name:
       - rhosp-openvswitch

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -43,7 +43,7 @@
       - not rhsm_enabled
     block:
       - name: install rhos-release
-        yum:
+        package:
           state: installed
           name:
           - http://download.devel.redhat.com/rcm-guest/puddles/OpenStack/rhos-release/rhos-release-latest.noarch.rpm
@@ -112,14 +112,14 @@
           name: tripleo.operator.tripleo_repos
 
   - name: Upgrade all packages # noqa 403
-    yum:
+    package:
       name: '*'
       state: latest
-    register: yum
+    register: packages
 
   - name: Reboot if we updated packages # noqa 503
     reboot:
-    when: yum.changed
+    when: packages.changed
 
   - name: Set FQDN
     set_fact:

--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -4,7 +4,7 @@
 - name: install crypto library for openssl_* modules
   become: true
   become_user: root
-  yum:
+  package:
     state: installed
     name: python3-cryptography
 


### PR DESCRIPTION
We should use the `package` module instead of `yum` to avoid
compatibility issues on RHEL systems.
