### PR TITLE
prepare_stack: create allow_ssh security group

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -111,6 +111,15 @@
     environment:
       OS_CLOUD: standalone
 
+  - name: Create basic security group which allow SSH # noqa 301
+    shell: |
+      if ! openstack security group show allow_ssh; then
+          openstack security group create allow_ssh --project openshift
+          openstack security group rule create --protocol tcp --dst-port 22 --project openshift allow_ssh
+      fi
+    environment:
+      OS_CLOUD: standalone
+
   # openstack cli doesn't have manila support (no openstack share type ...)in RHEL/OSP
   - name: Create Manila share type for CephFS NFS # noqa 301
     when: manila_enabled


### PR DESCRIPTION
Create a security group that has a rule which authorizes SSH.
It can be used by anyone who need to allow SSH on their workloads, so
they don't have to do create it manually.

The name of the security group is `allow_ssh`.
