### PR TITLE
Allow to disable swift for the openshift user

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -21,7 +21,7 @@
       if ! openstack user show openshift; then
           openstack user create --password '{{ openshift_password }}' openshift
       fi
-      for r in _member_ member swiftoperator; do
+      for r in _member_ member; do
           if openstack role show $r; then
               openstack role add --user openshift --project openshift $r
           fi
@@ -57,6 +57,12 @@
 
     environment:
       OS_CLOUD: standalone
+
+  - name: Add swiftoperator role for openshift user
+    command: openstack role add --user openshift --project openshift swiftoperator
+    environment:
+      OS_CLOUD: standalone
+    when: swiftoperator_enabled
 
   - name: Create flavors # noqa 301
     shell: |

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -109,6 +109,13 @@ manila_enabled: false
 manila_services:
   - OS::TripleO::Services::CephNfs
 
+# Whether or not we want to add the swiftoperator role to
+# the openshift user in openshift project (in Keystone).
+# Set this to false and the openshift user won't have access
+# to Swift. It can be useful if you want to force OpenShift to
+# deploy the Image registry in Cinder instead of Swift.
+swiftoperator_enabled: true
+
 # Enable SSL for the OpenStack public endpoints
 ssl_enabled: true
 # To use your own certificates and key, set these variables, otherwise


### PR DESCRIPTION
Add a new option `swiftoperator_enabled` (true by default).

It helps to configure whether or not we want to add the swiftoperator role to
the openshift user in openshift project (in Keystone).
Set this to false and the openshift user won't have access
to Swift. It can be useful if you want to force OpenShift to
deploy the Image registry in Cinder instead of Swift.
