### PR TITLE
Add working example of overrides for tripleomaster deployment

### DIFF
--- a/example-overrides/local-overrides-centos8-tripleo-master.yaml
+++ b/example-overrides/local-overrides-centos8-tripleo-master.yaml
@@ -1,0 +1,5 @@
+standalone_host: <standalone FQDN>
+public_api: <IP address used to reach the node>
+tripleo_repos_repos:
+  - current-tripleo-dev
+  - ceph


### PR DESCRIPTION
If we want to deploy TripleO master, we need to use current-tripleo-dev
repo and not current-tripleo, let's just document it here in an example
that was tested and worked fine.
