### PR TITLE
Add a condition to reboot the node after deployment

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -394,7 +394,7 @@
 
   - name: Reboot if SR-IOV is enabled (to apply kernel changes)
     when:
-      - sriov_interface is defined
+      - sriov_interface is defined or dpdk_kernel_args is defined
     block:
       - name: Reboot the node
         become_user: root


### PR DESCRIPTION
If we deploy OSP with Kernel args, we need to reboot. It's possible to
configure Kernel args without SR-IOV, so let's add a condition, that
will reboot if we use dpdk_kernel_args param.
