### PR TITLE
Manila changes

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -228,7 +228,7 @@
         standalone_extra_config: "{{ standalone_extra_config | combine(manila_extra_config) }}"
       vars:
         manila_extra_config:
-          ganesha_vip: "{{ control_plane_ip }}"
+          ganesha_vip: "{{ public_api }}"
 
     - name: Ensure ceph is enabled
       set_fact:

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -158,7 +158,7 @@
     - name: Disable snapshot support on pre-Wallaby Manila
       when: ansible_facts.packages['python3-manilaclient'][0].version is version('2.7.0', '<=')
       shell: |
-        manila type-key snapshot_support false
+        manila type-key default set snapshot_support=False
       environment: "{{ legacy_vars | combine(extra_vars) }}"
       vars:
         legacy_vars: "{{ os_env_vars.stdout | from_json }}"


### PR DESCRIPTION
* Switch ganesha_vip to use the public IP.
  The reason is that VMs have no access to the control plane network (by
  security reasons), so we would need a routable IP that the workloads
  running in a VM can reach. For now let's use the public IP which
  shouldn't be an issue. However we'll add IPtables rules to secure its
  access from the OSP cloud only.

* Fix the snapshot support command, it was wrong and the syntax has been
  fixed.
