### PR TITLE
Allow to deploy OSP with CPU partitioning without SR-IOV

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -177,6 +177,10 @@
     set_fact:
       sriov_services_fact: "{{ sriov_interface|default(None)| ternary(sriov_services, []) }}"
 
+  - name: Set fact for DPDK services overrides
+    set_fact:
+      dpdk_services_fact: "{{ dpdk_kernel_args|default(None)| ternary(dpdk_services, []) }}"
+
   - name: Set fact for Manila services overrides
     set_fact:
       manila_services_fact: "{{ manila_enabled | ternary(manila_services, []) }}"
@@ -202,7 +206,8 @@
     set_fact:
       role_data: >
         {% set _ = new_role_data.0.__setitem__('ServicesDefault', new_role_data.0.ServicesDefault |
-        union(sriov_services_fact) | union(manila_services_fact) | union(dcn_services_fact) | union(standalone_role_overrides)) %}
+        union(sriov_services_fact) | union(dpdk_services_fact) | union(manila_services_fact) |
+        union(dcn_services_fact) | union(standalone_role_overrides)) %}
         {{ new_role_data }}
 
   - name: Create the new role file

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -133,7 +133,10 @@ update_local_pki: false
 
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent
+
+dpdk_services:
   - OS::TripleO::Services::BootParams
+
 #sriov_interface:
 #sriov_nic_numvfs:
 #sriov_nova_pci_passthrough:


### PR DESCRIPTION
If we set the `dpdk_kernel_args` parameter but don't want SR-IOV to be
configured, we can now do it with that patch, since we separate the
list of services for DPDK & SR-IOV.
