### PR TITLE
Remove DPDK variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ There is no need to mount /var/lib/cinder and /var/lib/nova separately if / is l
 
 ### NFV enablement
 
-This section contains configuration procedures for single root input/output virtualization (SR-IOV) and
-dataplane development kit (DPDK) for network functions virtualization infrastructure (NFVi) in 
+This section contains configuration procedures for single root input/output virtualization (SR-IOV)
+for network functions virtualization infrastructure (NFVi) in 
 your Standalone OpenStack deployment. 
 Unfortunately, most of these parameters don't have default values nor can be automatically figured out in
 a Standalone type environment.
@@ -120,18 +120,15 @@ To understand how the SR-IOV configuration works, please have a look at this [up
 | `sriov_nic_numvfs` | `[undefined]` | Number of Virtual Functions that the NIC can handle. |
 | `sriov_nova_pci_passthrough` | `[undefined]` | List of PCI Passthrough whitelist parameters. [Guidelines](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/configuring-pci-passthrough#guidelines-for-configuring-novapcipassthrough-osp) to configure it. |
 
-DPDK Variables
---------------
+Kernel Variables
+----------------
 
-Please read the [official manual](https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html-single/network_functions_virtualization_planning_and_configuration_guide/index#concept_ovsdpdk-cpu-parameters)
-to understand better about the following parameters, they'll help you to figure out what values can be set, which
-couldn't be automatically set for you by dev-install.
+It is possible to configure the Kernel to boot with specific arguments:
 
 | Name              | Default Value       | Description          |
 |-------------------|---------------------|----------------------|
-| `dpdk_kernel_args` | `[undefined]` | Kernel arguments to configure when booting the machine. |
-| `dpdk_isol_cpus_list` | `[undefined]` | A set of CPU cores isolated from the host processes represented via a comma-separated list or range of physical host CPU numbers to which processes for pinned instance CPUs can be scheduled.
-| `dpdk_cpu_shared_set` | `[undefined]` | A comma-separated list or range of physical host CPU numbers used to determine the host CPUs for instance emulator threads.
+| `kernel_services` | `['TripleO::Services::BootParams']` | List of TripleO services to add to the default Standalone role |
+| `kernel_args` | `[undefined]` | Kernel arguments to configure when booting the machine. |
 
 ### SSL for public endpoints
 

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -177,9 +177,9 @@
     set_fact:
       sriov_services_fact: "{{ sriov_interface|default(None)| ternary(sriov_services, []) }}"
 
-  - name: Set fact for DPDK services overrides
+  - name: Set fact for Kernel services overrides
     set_fact:
-      dpdk_services_fact: "{{ dpdk_kernel_args|default(None)| ternary(dpdk_services, []) }}"
+      kernel_services_fact: "{{ kernel_args|default(None)| ternary(kernel_services, []) }}"
 
   - name: Set fact for Manila services overrides
     set_fact:
@@ -206,7 +206,7 @@
     set_fact:
       role_data: >
         {% set _ = new_role_data.0.__setitem__('ServicesDefault', new_role_data.0.ServicesDefault |
-        union(sriov_services_fact) | union(dpdk_services_fact) | union(manila_services_fact) |
+        union(sriov_services_fact) | union(kernel_services_fact) | union(manila_services_fact) |
         union(dcn_services_fact) | union(standalone_role_overrides)) %}
         {{ new_role_data }}
 
@@ -334,13 +334,12 @@
         - /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml
     when: ceph_enabled
 
-  - name: Install all tuned profiles if SR-IOV is enabled
+  - name: Install all tuned profiles
     yum:
       name:
       - tuned-profiles-*
     become: true
     become_user: root
-    when: dpdk_kernel_args is defined
 
   - name: Add sriov to enabled services
     set_fact:
@@ -399,7 +398,7 @@
 
   - name: Reboot if SR-IOV is enabled (to apply kernel changes)
     when:
-      - sriov_interface is defined or dpdk_kernel_args is defined
+      - sriov_interface is defined or kernel_args is defined
     block:
       - name: Reboot the node
         become_user: root

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -60,12 +60,8 @@ parameter_defaults:
   NeutronPhysicalDevMappings: "hostonly:{{ sriov_interface }}"
   NovaPCIPassthrough: {{sriov_nova_pci_passthrough | mandatory | to_json }}
 {% endif %}
-{% if dpdk_kernel_args is defined %}
-  KernelArgs: "{{ dpdk_kernel_args | mandatory }}"
-  IsolCpusList: "{{ dpdk_isol_cpus_list | mandatory }}"
-  NovaComputeCpuDedicatedSet: "{{ dpdk_isol_cpus_list | mandatory }}"
-  NovaComputeCpuSharedSet: "{{ dpdk_cpu_shared_set | mandatory }}"
-  TunedProfileName: cpu-partitioning
+{% if kernel_args is defined %}
+  KernelArgs: "{{ kernel_args }}"
 {% endif %}
   StandaloneEnableRoutedNetworks: false
   StandaloneHomeDir: "{{ ansible_env.HOME }}"

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -134,16 +134,15 @@ update_local_pki: false
 sriov_services:
   - OS::TripleO::Services::NeutronSriovAgent
 
-dpdk_services:
+kernel_services:
   - OS::TripleO::Services::BootParams
 
 #sriov_interface:
 #sriov_nic_numvfs:
 #sriov_nova_pci_passthrough:
 
-#dpdk_kernel_args:
-#dpdk_isol_cpus_list:
-#dpdk_cpu_shared_set:
+# Kernel arguments to add at boot
+#kernel_args:
 
 # This should not be changed unless you know what you're doing
 # because CentOS8 stream is now the only distro supported when deploying


### PR DESCRIPTION
They are too rigid, let's just keep the kernel_args for now.
Users can still use extra_heat_params for their DPDK configs.
