### PR TITLE
prepare_host: fix needs-reboot task

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -125,6 +125,8 @@
     shell: |
       needs-restarting -r
     register: needs_reboot
+    # the commands can return non-zero codes if reboot is needed
+    ignore_errors: true
 
   - name: Reboot if we updated packages # noqa 503
     reboot:


### PR DESCRIPTION
The task will be marked as failed when the reboot is needed, this patch
fixes that by ignoring the error. It is fine, because a non-zero return
code means a reboot is needed.
