### PR TITLE
install_stack: Add low memory option

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -349,6 +349,14 @@
         - /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovn-sriov.yaml
     when: sriov_interface is defined
 
+  - name: Reduce the number of workers
+    set_fact:
+      service_envs: "{{ service_envs | union(lowmem_env) }}"
+    vars:
+      lowmem_env:
+        - /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml
+    when: low_memory_usage
+
   - name: Create default_tripleo_envs fact
     set_fact:
       default_tripleo_envs:

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -76,6 +76,10 @@ standalone_role: /usr/share/openstack-tripleo-heat-templates/roles/Standalone.ya
 standalone_role_overrides: []
 standalone_extra_config: {}
 
+# Sets the number of Neutron/Nova/... workers to 1
+# Uses the environement file low-memory-usage.yaml
+low_memory_usage: false
+
 # This variable allows to add extra Heat parameters to standalone_parameters.yaml.
 # e.g.  extra_heat_params:
 #         NovaReservedHostMemory: 4096


### PR DESCRIPTION
Enables the env file /usr/share/openstack-tripleo-heat-templates/environments/low-memory-usage.yaml,
this reduces the RAM usage from 16GB to 6GB.