### PR TITLE
Save one reboot when using SR-IOV or Kernel args

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -406,6 +406,7 @@
 
   - name: Reboot if SR-IOV is enabled (to apply kernel changes)
     when:
+      # if a new condition is added here, it needs to match with the block in `playbooks/prepare_host.yaml`.
       - sriov_interface is defined or kernel_args is defined
     block:
       - name: Reboot the node

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -121,16 +121,21 @@
       name: '*'
       state: latest
 
-  - name: Check if reboot is required # noqa 301
-    shell: |
-      needs-restarting -r
-    register: needs_reboot
-    # the commands can return non-zero codes if reboot is needed
-    ignore_errors: true
-
-  - name: Reboot if we updated packages # noqa 503
-    reboot:
-    when: needs_reboot.rc == 1
+  - name: Reboot the node when necessary
+    when:
+      # We don't need to reboot when these parameters are defined because
+      # we'll reboot after the tripleo deployment anyway. We're saving one reboot.
+      - not (sriov_interface is defined or kernel_args is defined)
+    block:
+      - name: Check if reboot is required # noqa 301
+        shell: |
+          needs-restarting -r
+        register: needs_reboot
+        # the commands can return non-zero codes if reboot is needed
+        ignore_errors: true
+      - name: Reboot if we updated packages # noqa 503
+        reboot:
+        when: needs_reboot.rc == 1
 
   - name: Set FQDN
     set_fact:


### PR DESCRIPTION
We do not need to reboot after upgrading the rpms if we deploy TripleO
with SR-IOV or/and Kernel args, because we reboot anyway right after
TripleO being deployed. We'll save one reboot.
