### PR TITLE
Add support for cephadm instead of ceph-ansible

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -153,10 +153,40 @@
   - name: Install the tripleo client
     yum:
       name:
-      - ceph-ansible
       - python3-tripleoclient
     become: true
     become_user: root
+
+  - name: Prepare the deployment for Ceph
+    when: ceph_enabled
+    block:
+      - name: Check if ceph-ansible can be used to deploy Ceph
+        stat:
+          path: /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible
+        register: st_ceph
+      - name: Create ceph_ansible_enabled fact
+        set_fact:
+          ceph_ansible_enabled: "{{ st_ceph.stat.isdir is defined and st_ceph.stat.isdir }}"
+      - name: Show a message when ceph_devices is used but empty
+        debug:
+          msg: >
+            ceph_devices contains a list of disks but cephadm is going to use all available SSD/NVME disks.
+            Set the param to true to skip this message or remove it if you don't have available SSD/NVME disks.
+        when:
+          - not ceph_ansible_enabled
+          - ceph_devices is defined
+          - ceph_devices is not true
+          - (ceph_devices | length) > 0
+      - name: Create ceph facts
+        set_fact:
+          ceph_env_base: "{{ ceph_ansible_enabled | ternary('ceph-ansible', 'cephadm') }}"
+          ceph_env_name: "{{ ceph_ansible_enabled | ternary('ceph-ansible', 'cephadm-rbd-only') }}"
+      - name: "Install {{ ceph_package }}"
+        yum:
+          name:
+          - "{{ ceph_env_base }}"
+        become: true
+        become_user: root
 
   - name: Create dev-install_net_config.yaml
     template:
@@ -224,7 +254,7 @@
         service_envs: "{{ service_envs | union(manila_env) }}"
       vars:
         manila_env:
-        - /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-mds.yaml
+        - "/usr/share/openstack-tripleo-heat-templates/environments/{{ ceph_env_base }}/ceph-mds.yaml"
         - /usr/share/openstack-tripleo-heat-templates/environments/manila-cephfsganesha-config.yaml
 
     # This works round https://bugs.launchpad.net/tripleo/+bug/1911022
@@ -331,7 +361,7 @@
       service_envs: "{{ service_envs | union(ceph_env) }}"
     vars:
       ceph_env:
-        - /usr/share/openstack-tripleo-heat-templates/environments/ceph-ansible/ceph-ansible.yaml
+        - "/usr/share/openstack-tripleo-heat-templates/environments/{{ ceph_env_base }}/{{ ceph_env_name }}.yaml"
     when: ceph_enabled
 
   - name: Install all tuned profiles

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -84,6 +84,7 @@ parameter_defaults:
     tripleo_kernel_defer_reboot: true
 {% if ceph_enabled %}
 {% if ceph_devices is defined %}
+{% if ceph_ansible_enabled %}
   CephAnsibleDisksConfig:
     osd_scenario: lvm
     osd_objectstore: bluestore
@@ -91,8 +92,18 @@ parameter_defaults:
 {% for device in ceph_devices %}
     - {{ device }}
 {% endfor %}
+{% else %}
+  # Install Ceph OSD on non-rotational (SSD, NVME etc) to get
+  # good enough performances for workloads like OpenShift (etcd, etc).
+  CephOsdSpec:
+    data_devices:
+      rotational: 0
+    db_devices:
+      rotational: 0
+{% endif %}
   NovaEnableRbdBackend: true
 {% else %}
+{% if ceph_ansible_enabled %}
   CephAnsibleDisksConfig:
     osd_scenario: lvm
     osd_objectstore: bluestore
@@ -101,6 +112,12 @@ parameter_defaults:
         data_vg: vg_ceph
         db: db
         db_vg: vg_ceph
+{% else %}
+  CephOsdSpec:
+    data_devices:
+      paths:
+        - /dev/vg_ceph/data
+{% endif %}
   # Since we use a loop device for Ceph disk, performances wouldn't be great enough
   # to boot VMs with heavy workloads on it.
   # This can be overriden by setting:
@@ -109,11 +126,14 @@ parameter_defaults:
   # But to use at your own risks.
   NovaEnableRbdBackend: false
 {% endif %}
+{% if ceph_ansible_enabled %}
   CephAnsibleExtraConfig:
     cluster_network: {{ control_plane_cidr }}
     public_network: {{ control_plane_cidr }}
+{% endif %}
   CephPoolDefaultPgNum: 8
   CephPoolDefaultSize: 1
+  CephSpecFqdn: true
 {% endif %}
 {% if rhsm_enabled %}
   ContainerImageRegistryCredentials:


### PR DESCRIPTION
Ceph has given up ceph-ansible and therefore TripleO had to remove its
support going forward.

This patch will detect if ceph-ansible can still be used and if not
it'll configure ceph using `cephadm`.

From a user standpoint, dev-install still offers 3 options:

* Disable the management of Ceph from dev-install; if users don't want
  Ceph or if they want to use `extra_heat_params`.
* Let cephadm to install Ceph OSDs on available disks that aren't
  rotational (for performance purposes). This is different from
  ceph-ansible where we could choose the disks, but one can achieve it
  via option 1 if they don't have SSD/NVME disks.
* Let dev-install creating LVM resources on a loop device and let
  cephadm to use these volumes to configure Ceph. Note that cephadm
  doesn't need the DB volume but this shouldn't matter anyway, as the
  data volume should be big enough to run the workloads (volumes, vms,
  etc), since it's 96% of the total size of the loop device.

In other words, this change is backward compatible except if you
deployed Ceph with `ceph_devices` that are rotational; then no OSD will
be deployed and cephadm will crash. In that case it's suggested to go
with option 1 previously described, but dev-install maintainers don't
suggest to install Ceph on these disks because of performance impact.
