### PR TITLE
DCN: enable dynamic compute discovery

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -154,6 +154,7 @@ parameter_defaults:
 {% endif %}
 {% if dcn_az is defined %}
 {% if dcn_az == 'central' %}
+  NovaSchedulerDiscoverHostsInCellsInterval: 120
   GlanceBackendID: central
   GlanceEnabledImportMethods: web-download,copy-image
   GlanceStoreDescription: 'central rbd glance store'


### PR DESCRIPTION
When deploying a `central` node, let's enable
NovaSchedulerDiscoverHostsInCellsInterval parameter in TripleO; which
will check if a new compute is deployed every 2 minutes.
When detected, it will add the new compute to the cell and the compute
will be able to be schedulable for new VMs.

Note: this feature is by default disabled in TripleO because there is
a race condition with Ironic, but since we don't deploy/use baremetal
API here, we can safely enable it.
