### PR TITLE
Configure MTU on dummy interface, not the bridge

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -17,7 +17,6 @@ network_config:
 - type: ovs_bridge
   name: br-ctlplane
   use_dhcp: false
-  mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
   ovs_extra:
   - br-set-external-id br-ctlplane bridge-id br-ctlplane
   addresses:
@@ -26,6 +25,7 @@ network_config:
   - type: interface
     name: dummy0
     nm_controlled: true
+    mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
 {% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-ctlplane-{{ ip | to_uuid }}"
@@ -37,7 +37,6 @@ network_config:
 - type: ovs_bridge
   name: br-hostonly
   use_dhcp: false
-  mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
   ovs_extra:
   - br-set-external-id br-hostonly bridge-id br-hostonly
   addresses:
@@ -67,5 +66,6 @@ network_config:
   - type: interface
     name: dummy1
     nm_controlled: true
+    mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
The bridge takes the highest MTU of the interfaces connected to it.
So it was always set to 1500 even if we force it to 1400, because dummy
nics were using 1500.

Now that we set it to 1400, the bridge will be 1400 too, and it helps
when setting up VXLAN tunnels in multinode environment.

This has been tested against a real environment.
