### PR TITLE
External network to be shared

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -93,7 +93,7 @@
   - name: Create external network
     shell: |
       if ! openstack network show external; then
-          openstack network create --external --provider-physical-network external --provider-network-type flat external
+          openstack network create --share --external --provider-physical-network external --provider-network-type flat external
       fi
       if ! openstack subnet show external-subnet; then
           openstack subnet create external-subnet --subnet-range "{{ external_cidr }}" \


### PR DESCRIPTION
If you are deploying by openshift project, the external network needs to be shared. So you can later create a floating ips for the openshift installer.