### PR TITLE
Fix check for manila pre-wallaby version

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -159,7 +159,7 @@
         manager: auto
 
     - name: Disable snapshot support on pre-Wallaby Manila
-      when: ansible_facts.packages['python3-manilaclient'][0].version is version('2.7.0', '<=')
+      when: ansible_facts.packages['python3-manilaclient'][0].version is version('2.6.0', '<')
       shell: |
         manila type-key default set snapshot_support=False
       environment: "{{ legacy_vars | combine(extra_vars) }}"


### PR DESCRIPTION
According to [1], manilaclient is at version 2.6.0 in Wallaby, while it
is at version 2.3.0 in Victoria. The check should test if manilaclient
version is strictly inferior to 2.6.0.

[1] https://trunk.rdoproject.org/centos8-wallaby/component/clients/current/
[1] https://trunk.rdoproject.org/centos8-victoria/component/clients/current/