### PR TITLE
Safe defaults to install OSP 16.1 and 16.2

### DIFF
--- a/example-overrides/local-overrides-osp16-2.yaml
+++ b/example-overrides/local-overrides-osp16-2.yaml
@@ -1,4 +1,42 @@
 standalone_host: <standalone FQDN>
 public_api: <IP address used to reach the node>
-# Get latest 16.2 puddle
-rhos_release: 16.2
+rhsm_enabled: true
+redhat_registry_credentials: "'<user>': '<password>'"
+rhsm_org_id: "<ID>"
+#rhsm_activation_key: "<secrete>"
+rhsm_release: 8.4
+rhsm_container_tools_version: 3.0
+rhsm_repos:
+  - rhel-8-for-x86_64-baseos-eus-rpms
+  - rhel-8-for-x86_64-appstream-eus-rpms
+  - rhel-8-for-x86_64-highavailability-eus-rpms
+  - ansible-2.9-for-rhel-8-x86_64-rpms
+  - openstack-beta-for-rhel-8-x86_64-rpms
+  - fast-datapath-for-rhel-8-x86_64-rpms
+  - advanced-virt-for-rhel-8-x86_64-rpms
+  - rhceph-4-tools-for-rhel-8-x86_64-rpms
+virt_release: av
+cip_config:
+  - set:
+      ceph_alertmanager_image: ose-prometheus-alertmanager
+      ceph_alertmanager_namespace: registry.redhat.io/openshift4
+      ceph_alertmanager_tag: 4.1
+      ceph_grafana_image: rhceph-4-dashboard-rhel8
+      ceph_grafana_namespace: registry.redhat.io/rhceph
+      ceph_grafana_tag: 4
+      ceph_image: rhceph-4-rhel8
+      ceph_namespace: registry.redhat.io/rhceph
+      ceph_node_exporter_image: ose-prometheus-node-exporter
+      ceph_node_exporter_namespace: registry.redhat.io/openshift4
+      ceph_node_exporter_tag: v4.1
+      ceph_prometheus_image: ose-prometheus
+      ceph_prometheus_namespace: registry.redhat.io/openshift4
+      ceph_prometheus_tag: 4.1
+      ceph_tag: latest
+      name_prefix: openstack-
+      name_suffix: ''
+      namespace: registry.redhat.io/rhosp-beta
+      neutron_driver: ovn
+      rhel_containers: false
+      tag: '16.2'
+    tag_from_label: '{version}-{release}'

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -45,7 +45,7 @@
       - name: Install virt module
         shell: |
           dnf module disable -y virt:rhel
-          dnf module enable -y virt:"{{ rhsm_release }}"
+          dnf module enable -y virt:"{{ virt_release }}"
 
   - name: Prepare host on RHEL system with rhos-release
     when:

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -1,5 +1,5 @@
 ---
-rhos_release: 16.2
+rhos_release: 16.1
 hostname: standalone
 clouddomain: shiftstack
 
@@ -172,6 +172,8 @@ rhsm_repos:
 rhsm_method: "portal"
 rhsm_release: 8.2
 rhsm_container_tools_version: '2.0'
+# Note: to install 16.2 on RHEL 8.4, you need virt_release set to "av"
+virt_release: 8.2
 # Red Hat Registry credentials have to be set when deploying OSP on RHEL
 # redhat_registry_credentials
 


### PR DESCRIPTION
## Adding example config for deploying 16.2 beta
* Add an example of 16.2-beta config.
* Introduce `virt_release` to override the default virt:rhel module that is installed. Note that the virt module needs to be set to `av` on RHEL 8.4 and onward.

## Improve defaults for 16.1 when using puddles
16.2 is not GA'ed yet so it's safer to use 16.1 when downloading content from puddles. Content from 16.2 might be unstable.
