### PR TITLE
PCI passthrough local_override.yaml example

### DIFF
--- a/example-overrides/local-overrides-osp16-2-with-pcipassthrough.yaml
+++ b/example-overrides/local-overrides-osp16-2-with-pcipassthrough.yaml
@@ -1,0 +1,23 @@
+standalone_host: <standalone FQDN>
+public_api: <IP address used to reach the node>
+# Get latest 16.2 puddle
+rhos_release: 16.2
+
+
+# PCIPassthrough example for device " 0b:00.0 VGA compatible controller [0300]: Matrox Electronics Systems Ltd. G200eR2 [102b:0534] (rev 01)"
+# For available device_type values see https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/configuring-pci-passthrough
+standalone_extra_config:
+  nova::pci::aliases:
+  - name: "VGAalias"
+    vendor_id: "102b"
+    product_id: "0534"
+    device_type: "type-PCI"
+
+extra_heat_params:
+  NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter','NUMATopologyFilter']
+  NovaSchedulerAvailableFilters: ["nova.scheduler.filters.all_filters","nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter"]
+  NovaPCIPassthrough:
+    - vendor_id: "102b"
+      product_id: "0534"
+
+kernel_args: "iommu=pt intel_iommu=on"


### PR DESCRIPTION
All the necessary parameters to configured pci passthrough can be specified in the local_override.yaml file