### PR TITLE
Combined improvements for Manila

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -263,7 +263,12 @@
         standalone_extra_config: "{{ standalone_extra_config | combine(manila_extra_config) }}"
       vars:
         manila_extra_config:
+          # Needed by Pacemaker to create the VIP
           ganesha_vip: "{{ public_api }}"
+          # for ceph-ansible support on OSP 16.x
+          ceph_nfs_bind_addr: "{{ public_api }}"
+          # for cephadm support on OSP 17
+          tripleo_cephadm_ceph_nfs_bind_addr: "{{ public_api }}"
 
     - name: Ensure ceph is enabled
       set_fact:

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -265,8 +265,6 @@
         manila_extra_config:
           # Needed by Pacemaker to create the VIP
           ganesha_vip: "{{ public_api }}"
-          # for ceph-ansible support on OSP 16.x
-          ceph_nfs_bind_addr: "{{ public_api }}"
           # for cephadm support on OSP 17
           tripleo_cephadm_ceph_nfs_bind_addr: "{{ public_api }}"
 

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -169,6 +169,13 @@
           # https://bugzilla.redhat.com/show_bug.cgi?id=1960710
           OS_SHARE_API_VERSION: 2.60
 
+    - name: Increase default quotas for shares and snapshots
+      shell: |
+        manila quota-update --shares 150 --snapshots 150 openshift
+      environment: "{{ legacy_vars }}"
+      vars:
+        legacy_vars: "{{ os_env_vars.stdout | from_json }}"
+
   - name: Read clouds.yaml
     slurp:
       src: &cloudsyamlpath /home/stack/.config/openstack/clouds.yaml

--- a/playbooks/templates/standalone_parameters.ceph_ansible.yaml.j2
+++ b/playbooks/templates/standalone_parameters.ceph_ansible.yaml.j2
@@ -21,3 +21,6 @@
   CephAnsibleExtraConfig:
     cluster_network: {{ control_plane_cidr }}
     public_network: {{ control_plane_cidr }}
+{% if manila_enabled %}
+    ceph_nfs_bind_addr: "{{ public_api }}"
+{% endif %}


### PR DESCRIPTION
## Add required variables for Ganesha to listen on public network

A few months ago we decided that Manila shares would listen on public
network, because we don't have a storage network in Standalone.

For that to happen, we need to configure Ganesha to listen on the
public network (and not the control plane), so we need to configuring
the following:

* ganesha_vip: for pacemaker to create the VIP
* ceph_nfs_bind_addr: for ceph-ansible, taking care of configuring
  ganesha with the public IP
* tripleo_cephadm_ceph_nfs_bind_addr: for cephadm, taking care via
  tripleo-ansible of configuring ganesha with the public IP.


## Increase default quotas for Manila
50 shares doesn't seem enough when running the CSI test suite in parallel mode.
Let's increase it to 150 shares and 150 snapshots