### PR TITLE
Lower the Neutron global MTU in multinode

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -25,7 +25,7 @@ network_config:
   - type: interface
     name: dummy0
     nm_controlled: true
-    mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
+    mtu: {{ dcn_az | ternary(1400, 1500) }}
 {% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-ctlplane-{{ ip | to_uuid }}"
@@ -66,6 +66,6 @@ network_config:
   - type: interface
     name: dummy1
     nm_controlled: true
-    mtu: {{ tunnel_remote_ips | ternary(1400, 1500) }}
+    mtu: {{ dcn_az | ternary(1400, 1500) }}
 {% endif %}
 {% endif %}

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -136,6 +136,11 @@ parameter_defaults:
   NovaComputeAvailabilityZone: {{ dcn_az }}
   NovaCrossAZAttach: false
   OVNCMSOptions: "enable-chassis-as-gw,availability-zones={{ dcn_az }}"
+  # In multinode, we create VXLAN tunnels to connect the br-ctlplane bridges
+  # and on top of it, Neutron tenant networks will also have tunnels so
+  # we need to lower the MTU to 1300 which should be safe to do Geneve tunnels
+  # over VXLAN.
+  NeutronGlobalPhysnetMtu: 1300 
 {% endif %}
 {% if standalone_extra_config|length > 0 or dcn_az is defined %}
   StandaloneExtraConfig:


### PR DESCRIPTION
When doing multinode, we connect the br-ctlplane bridges with VXLAN
tunnels, so the bridge has an MTU of 1400 (since the interface has
1500 in most infras).

However when creating Neutron tenant networks that will use overlay, on
top of these bridges, we need to lower the default MTU (1500) to work
in this setup, so using 1300 should be safe, since the tunnels are
1400.
