### PR TITLE
Configure Cinder API to allow users to set volume states

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -79,6 +79,10 @@ parameter_defaults:
   OctaviaCaKeyPassphrase: "secrete"
   OctaviaAmphoraSshKeyFile: "{{ ansible_env.HOME }}/octavia.pub"
   OctaviaAmphoraImageFilename: "{{ ansible_env.HOME }}/amphora.qcow2"
+  CinderApiPolicies:
+    cinder-vol-state-set:
+      key: "volume_extension:volume_admin_actions:reset_status"
+      value: "rule:admin_or_owner"
   # We never want the node to reboot during tripleo deploy, but defer to later
   StandaloneExtraGroupVars:
     tripleo_kernel_defer_reboot: true


### PR DESCRIPTION
By default, volume states can only be changed by admin but in
dev-install cases, we are operating our cloud and sometimes need to
reset the state of a volume.

e.g. in OpenShift CI, sometimes volumes aren't cleaned correctly and we
have to manually clear them up. Thanks to this patch, the tenant will
be able to set the state of their own volumes.
