### PR TITLE
Ignore error if yum/dnf fails on localhost

### DIFF
--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -4,6 +4,8 @@
 - name: install crypto library for openssl_* modules
   become: true
   become_user: root
+  # To not fail on non-RPM systems let's just ignore errors.
+  ignore_errors: true
   yum:
     state: installed
     name: python3-cryptography


### PR DESCRIPTION
We shouldn't assume the script is run on something having yum/dnf. Let's
ignore the error of the task requiring it and assume that user can
install it manually if it's not there.

Also it prevents from errors like below when user running the playbook
isn't added to `wheel` group. You can fix it with `sudo gpasswd -a
<user> wheel` BTW.

fatal: [standalone]: FAILED! => {"changed": false, "msg": ["Could not
detect which major revision of yum is in use, which is required to
determine module backend.", "You can manually specify
use_backend to tell the module whether to use the yum (yum3) or dnf
(yum4) backend})"]}
