### PR TITLE
Set KernelArgsDeferReboot to true

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -84,6 +84,7 @@ parameter_defaults:
       key: "volume_extension:volume_admin_actions:reset_status"
       value: "rule:admin_or_owner"
   # We never want the node to reboot during tripleo deploy, but defer to later
+  KernelArgsDeferReboot: true
   StandaloneExtraGroupVars:
     tripleo_kernel_defer_reboot: true
 


### PR DESCRIPTION
KernelArgsDeferReboot was added in recent releases to defer the reboot
after kernel args sets.

We handle the reboot ourselves in dev-install, since it's a standalone
install.

Before we were relying on Ansible group vars, but now we have
KernelArgsDeferReboot that sets Host vars for
tripleo_kernel_defer_reboot.
