### PR TITLE
Few fixes for OSP 16.2

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -257,17 +257,6 @@
         - "/usr/share/openstack-tripleo-heat-templates/environments/{{ ceph_env_base }}/ceph-mds.yaml"
         - /usr/share/openstack-tripleo-heat-templates/environments/manila-cephfsganesha-config.yaml
 
-    # This works round https://bugs.launchpad.net/tripleo/+bug/1911022
-    - name: Add manila extraconfig
-      set_fact:
-        standalone_extra_config: "{{ standalone_extra_config | combine(manila_extra_config) }}"
-      vars:
-        manila_extra_config:
-          # Needed by Pacemaker to create the VIP
-          ganesha_vip: "{{ public_api }}"
-          # for cephadm support on OSP 17
-          tripleo_cephadm_ceph_nfs_bind_addr: "{{ public_api }}"
-
     - name: Ensure ceph is enabled
       set_fact:
         ceph_enabled: true

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -367,12 +367,11 @@
         - "/usr/share/openstack-tripleo-heat-templates/environments/{{ ceph_env_base }}/{{ ceph_env_name }}.yaml"
     when: ceph_enabled
 
-  - name: Install tuned profiles useful for OSP
+  - name: Install tuned cpu partionioning profile
     yum:
       name:
       - tuned
       - tuned-profiles-cpu-partitioning
-      - tuned-profiles-realtime
     become: true
     become_user: root
 

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -154,6 +154,11 @@ parameter_defaults:
     oslo_messaging_notify_use_ssl: false
     oslo_messaging_rpc_use_ssl: false
 {% endif %}
+{% if manila_enabled %}
+    ganesha_vip: "{{ public_api }}"
+    # for cephadm support on OSP 17
+    tripleo_cephadm_ceph_nfs_bind_addr: "{{ public_api }}"
+{% endif %}
 {% for key, value in standalone_extra_config.items() %}
     {{ key }}: {{ value }}
 {% endfor %}


### PR DESCRIPTION
## Fix Manila extra config
Fix some extra config for Manila ganesha IP

## Fix for tuned
Tuned RT isn't available from OSP 16.2 and not really needed in
standalone use case.

Installing CPU partitioning should be enough.
