### PR TITLE
SR-IOV: add support for OVS

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -36,7 +36,9 @@
         - /usr/share/openstack-tripleo-heat-templates/environments/docker-ha.yaml
 
   - name: Enable OVN DVR HA by default when deploying DCN
-    when: dcn_az is defined
+    when:
+      - dcn_az is defined
+      - ovn_enabled
     block:
     - name: Add OVN DVR HA services
       set_fact:
@@ -364,13 +366,26 @@
     become: true
     become_user: root
 
-  - name: Add sriov to enabled services
+  - name: Add sriov-ovn to enabled services
     set_fact:
       service_envs: "{{ service_envs | union(sriov_env) }}"
     vars:
       sriov_env:
         - /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovn-sriov.yaml
-    when: sriov_interface is defined
+    when:
+      - sriov_interface is defined
+      - ovn_enabled
+
+  - name: Add sriov-ovs to enabled services
+    set_fact:
+      service_envs: "{{ service_envs | union(sriov_env) }}"
+    vars:
+      sriov_env:
+        - /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovs.yaml
+        - /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-sriov.yaml
+    when:
+      - sriov_interface is defined
+      - not ovn_enabled
 
   - name: Reduce the number of workers
     set_fact:

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -187,3 +187,6 @@ dcn_services:
 # A list of block devices which will be combined and used as ephemeral local
 # storage
 ephemeral_storage_devices: []
+
+# Whether or not we want OVN to be enabled
+ovn_enabled: true


### PR DESCRIPTION
Add a new parameter, called `ovn_enabled` set to True by default.
When set to False, OVS will be deployed instead of OVN when deploying
SR-IOV.
