### PR TITLE
Add a task to unregister RHSM

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -442,6 +442,17 @@
       - dcn_az == "central"
     script: files/export-dcn.sh
 
+  - name: Unregister the system from RHSM
+    when:
+      - ansible_facts.distribution == 'RedHat'
+      - rhsm_enabled
+      - rhsm_ephemeral
+    block:
+      - name: Unregister Red Hat Subscription Manager
+        import_role:
+          name: redhat-subscription
+          tasks_from: unregister.yml
+
   - name: Reboot if SR-IOV is enabled (to apply kernel changes)
     when:
       # if a new condition is added here, it needs to match with the block in `playbooks/prepare_host.yaml`.

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -160,6 +160,10 @@ authorized_keys: []
 
 # Red Hat Subscription Manager options
 rhsm_enabled: false
+# If the system is used for production, you want to keep
+# RHSM activated to get upgrades later; so in this case set it
+# to false.
+rhsm_ephemeral: true
 rhsm_repos:
   - rhel-8-for-x86_64-baseos-eus-rpms
   - rhel-8-for-x86_64-appstream-eus-rpms


### PR DESCRIPTION
Add a task to unregister RHSM from the system unless `rhsm_ephemeral`
is set to False.

Note that this is set to True by default because most of subscriptions
have limited numbers of systems.

In production or CI environments, you want to set it to False, so the
system can get upgrades on day 2.
