### PR TITLE
SRIOV: enable DHCP agent

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -1,7 +1,10 @@
 #vi:syntax=yaml
 
-{% if dcn_az is defined %}
 resource_registry:
+{% if sriov_interface is defined %}
+  OS::TripleO::Services::NeutronDhcpAgent: /usr/share/openstack-tripleo-heat-templates/deployment/neutron/neutron-dhcp-container-puppet.yaml
+{% endif %}
+{% if dcn_az is defined %}
   OS::TripleO::Services::NovaAZConfig: /usr/share/openstack-tripleo-heat-templates/deployment/nova/nova-az-config.yaml
 {% if dcn_az != 'central' %}
   OS::TripleO::Services::CinderVolume: /usr/share/openstack-tripleo-heat-templates/deployment/cinder/cinder-volume-container-puppet.yaml


### PR DESCRIPTION
The DHCP agent is still needed if we need the VMs to get an IP when
booting from "direct" type port. In OSP17, OVN will be able to provide
DHCP directly but this wasn't bacported yet to OSP16.

This patch will deploy the Neutron DHCP agent if SRIOV is being
configured on at least one interface. Note that the agent won't be used
by anything else than the SRIOV nic agent, since OVN provide DHCP for
regular ports.

Note 1: if we want to add the SRIOV interface to the OVS bridge, the only configuration supported today is via the OVS Hardware offload mechanism, which dev-install doesn't support well now. Note that this requires specific nics.
Note2: This limitation should disappear after this patch in Neutron: https://review.opendev.org/c/openstack/neutron/+/762550