### PR TITLE
Rework SRIOV integration

### DIFF
--- a/example-overrides/local-overrides-osp16-2-with-sriov-and-dpdk.yaml
+++ b/example-overrides/local-overrides-osp16-2-with-sriov-and-dpdk.yaml
@@ -1,7 +1,8 @@
 sriov_interface: enp130s0f0
 sriov_nova_pci_passthrough:
   - devname: "enp130s0f0"
-    physical_network: "hostonly-sriov"
+    physical_network: "hostonly"
+    trusted: true
 sriov_nic_numvfs: 63
 dpdk_interface: enp130s0f1
 kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=128 iommu=pt intel_iommu=on isolcpus=4-47"

--- a/example-overrides/local-overrides-osp16-2-with-sriov.yaml
+++ b/example-overrides/local-overrides-osp16-2-with-sriov.yaml
@@ -1,7 +1,8 @@
 sriov_interface: enp130s0f0
 sriov_nova_pci_passthrough:
   - devname: "enp130s0f0"
-    physical_network: "hostonly-sriov"
+    physical_network: "hostonly"
+    trusted: true
 sriov_nic_numvfs: 63
 kernel_args: "default_hugepagesz=1GB hugepagesz=1G hugepages=128 iommu=pt intel_iommu=on isolcpus=4-47"
 tuned_isolated_cores: "4-47"

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -131,21 +131,6 @@
     environment:
       OS_CLOUD: standalone
 
-  - name: Create hostonly-sriov network # noqa 301
-    when: sriov_interface is defined
-    shell: |
-      if ! openstack network show hostonly-sriov; then
-          openstack network create --project openshift --share --external --provider-physical-network hostonly-sriov --provider-network-type flat hostonly-sriov
-      fi
-      if ! openstack subnet show hostonly-sriov-subnet; then
-          openstack subnet create --project openshift hostonly-sriov-subnet --subnet-range "{{ hostonly_sriov_cidr }}" \
-              --no-dhcp --gateway none \
-              --allocation-pool "start={{ hostonly_sriov_fip_pool_start }},end={{ hostonly_sriov_fip_pool_end }}" \
-              --network hostonly-sriov
-      fi
-    environment:
-      OS_CLOUD: standalone
-
   - name: Create hostonly-dpdk network # noqa 301
     when: dpdk_interface is defined
     shell: |

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -14,6 +14,16 @@ network_config:
   - type: interface
     name: {{ network_info.public_ipv4.interface }}
     primary: true
+{% if sriov_interface is defined %}
+- type: sriov_pf
+  name: {{ sriov_interface }}
+  numvfs: {{ sriov_nic_numvfs | mandatory }}
+  use_dhcp: false
+  defroute: false
+  nm_controlled: true
+  hotplug: true
+  promisc: true
+{% endif %}
 - type: ovs_bridge
   name: br-ctlplane
   use_dhcp: false
@@ -58,14 +68,8 @@ network_config:
     nm_controlled: true
     mtu: {{ dcn_az is defined | ternary(1400, 1500) }}
 {% if sriov_interface is defined %}
-- type: sriov_pf
-  name: {{ sriov_interface }}
-  numvfs: {{ sriov_nic_numvfs | mandatory }}
-  mtu: 9000
-  use_dhcp: false
-  defroute: false
-  nm_controlled: true
-  hotplug: true
-  promisc: false
+  - type: sriov_vf
+    device: {{ sriov_interface }}
+    vfid: 0
 {% endif %}
 {% endif %}

--- a/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
+++ b/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
@@ -12,6 +12,16 @@ network_config:
   name: dummy0
   use_dhcp: false
   nm_controlled: true
+{% if sriov_interface is defined %}
+- type: sriov_pf
+  name: {{ sriov_interface }}
+  use_dhcp: false
+  numvfs: {{ sriov_nic_numvfs | mandatory }}
+  defroute: false
+  nm_controlled: true
+  hotplug: true
+  promisc: true
+{% endif %}
 - type: ovs_user_bridge
   name: br-hostonly
   use_dhcp: false
@@ -28,14 +38,9 @@ network_config:
     nm_controlled: true
     mtu: 1500
 {% if sriov_interface is defined %}
-- type: sriov_pf
-  name: {{ sriov_interface }}
-  use_dhcp: false
-  numvfs: {{ sriov_nic_numvfs | mandatory }}
-  defroute: false
-  nm_controlled: true
-  hotplug: true
-  promisc: false
+  - type: sriov_vf
+    device: {{ sriov_interface }}
+    vfid: 0
 {% endif %}
 - type: ovs_user_bridge
   name: br-dpdk

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -58,7 +58,7 @@ parameter_defaults:
   NeutronFlatNetworks: {{ neutron_flat_networks }}
 {% if sriov_interface is defined %}
   OVNCMSOptions: "enable-chassis-as-gw"
-  NeutronPhysicalDevMappings: "hostonly-sriov:{{ sriov_interface }}"
+  NeutronPhysicalDevMappings: "hostonly:{{ sriov_interface }}"
   NovaPCIPassthrough: {{sriov_nova_pci_passthrough | mandatory | to_json }}
 {% endif %}
 {% if dpdk_interface is defined %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -63,9 +63,6 @@ hostonly_fip_pool_start: "{{ hostonly_cidr | nthhost(2) }}"
 hostonly_fip_pool_end: "{{ hostonly_cidr | nthhost(-2) }}"
 
 # `hostonly` variants
-hostonly_sriov_cidr: 192.168.26.0/24
-hostonly_sriov_fip_pool_start: "{{ hostonly_sriov_cidr | nthhost(2) }}"
-hostonly_sriov_fip_pool_end: "{{ hostonly_sriov_cidr | nthhost(-2) }}"
 hostonly_dpdk_cidr: 192.168.27.0/24
 hostonly_dpdk_gateway: "{{ hostonly_dpdk_cidr | nthhost(1) }}"
 hostonly_dpdk_fip_pool_start: "{{ hostonly_dpdk_cidr | nthhost(2) }}"
@@ -105,7 +102,7 @@ low_memory_usage: false
 # This param can be overriden, but only when overriding the network_config, otherwise the default
 # should work as is:
 #neutron_bridge_mappings:
-neutron_flat_networks: "external,hostonly,hostonly-sriov,hostonly-dpdk"
+neutron_flat_networks: "external,hostonly,hostonly-dpdk"
 
 tripleo_repos_repos:
   - current-tripleo


### PR DESCRIPTION
* Re-use the br-hostonly network for simplicity. This provider network
  will be used so we avoid creating a new one, just for SRIOV. The
  network is already external and binded to a dummy interface.

* Plug a VF into the br-hostonly bridge, so the VMs that start from
  an SRIOV port will be able to get an IP and metadata (SSH keys, etc).

With this patch, I was able to:
* Create a Neutron port of type `direct` in the hostonly network.
* Start a VM using that port
* The VM could be SSH'ed and had Internet access