### PR TITLE
Improve SRIOV integration

### DIFF
--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -172,3 +172,13 @@
       network_name: hostonly
       network_cidr: "{{ hostonly_cidr }}"
       public_ip: "{{ network_info.public_ipv4.address }}"
+
+  - name: Configure SNAT for hostonly_sriov
+    include_role:
+      name: snat
+    vars:
+      network_name: hostonly-sriov
+      network_cidr: "{{ hostonly_sriov_cidr }}"
+      public_ip: "{{ network_info.public_ipv4.address }}"
+    when:
+    - sriov_interface is defined

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -139,7 +139,8 @@
       fi
       if ! openstack subnet show hostonly-sriov-subnet; then
           openstack subnet create --project openshift hostonly-sriov-subnet --subnet-range "{{ hostonly_sriov_cidr }}" \
-              --no-dhcp --gateway none \
+              --no-dhcp --gateway "{{ hostonly_sriov_gateway }}" \
+              --dns-nameserver "{{ network_info.dns | first }}" \
               --allocation-pool "start={{ hostonly_sriov_fip_pool_start }},end={{ hostonly_sriov_fip_pool_end }}" \
               --network hostonly-sriov
       fi

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -67,5 +67,7 @@ network_config:
   nm_controlled: true
   hotplug: true
   promisc: false
+  addresses:
+  - ip_netmask: {{ hostonly_sriov_gateway }}/{{ hostonly_sriov_prefix }}
 {% endif %}
 {% endif %}

--- a/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
+++ b/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
@@ -39,5 +39,7 @@ network_config:
   nm_controlled: true
   hotplug: true
   promisc: false
+  addresses:
+  - ip_netmask: {{ hostonly_sriov_gateway }}/{{ hostonly_sriov_prefix }}
 {% endif %}
 {% endif %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -64,6 +64,8 @@ hostonly_fip_pool_end: "{{ hostonly_cidr | nthhost(-2) }}"
 
 # `hostonly` variants
 hostonly_sriov_cidr: 192.168.26.0/24
+hostonly_sriov_gateway: "{{ hostonly_sriov_cidr | nthhost(1) }}"
+hostonly_sriov_prefix: "{{ hostonly_sriov_cidr | ipaddr('prefix') }}"
 hostonly_sriov_fip_pool_start: "{{ hostonly_sriov_cidr | nthhost(2) }}"
 hostonly_sriov_fip_pool_end: "{{ hostonly_sriov_cidr | nthhost(-2) }}"
 


### PR DESCRIPTION
With this patch, I'm able to create a port of type `direct` then boot
a VM from it, using --config-drive=True.

The VM will have its metadata/DHCP provided by Config Drive (not OVN
DHCP) and on the same node we can use the OVS for DPDK integration.
