### PR TITLE
Revert "Fix failure if netaddr isn't available on controller"

### DIFF
--- a/playbooks/roles/network_info/tasks/main.yaml
+++ b/playbooks/roles/network_info/tasks/main.yaml
@@ -1,11 +1,4 @@
 ---
-- name: Ensure python3-netaddr is available on controller for ansible ipaddr filter
-  become: true
-  delegate_to: localhost
-  package:
-    name: python3-netaddr
-    state: installed
-
 - name: Read network info if present
   slurp:
     src: &networkinfo /home/stack/dev-install-network-info.yaml


### PR DESCRIPTION
Reverts shiftstack/dev-install#166

This is a broken change, we'll address that later again.