### PR TITLE
Simplify DPDK integration with provider network

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -282,7 +282,7 @@
         - dpdk_interface is not defined
       - name: set fact for base_bridge_mappings when DPDK is enabled
         set_fact:
-          base_bridge_mappings: "hostonly:dummy1,hostonly-dpdk:br-dpdk"
+          base_bridge_mappings: "hostonly:br-hostonly"
         when:
         - dpdk_interface is defined
       - name: construct fact for neutron_bridge_mappings

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -67,13 +67,6 @@
               prefix-length: {{ control_plane_prefix | int }}
           ipv6:
             enabled: false
-        - name: dummy1
-          type: dummy
-          state: up
-          ipv4:
-            enabled: false
-          ipv6:
-            enabled: false
 
   # this saves the static route configuration including the default route
   # prior to filtering later
@@ -179,13 +172,3 @@
       network_name: hostonly
       network_cidr: "{{ hostonly_cidr }}"
       public_ip: "{{ network_info.public_ipv4.address }}"
-
-  - name: Configure SNAT for hostonly_dpdk
-    include_role:
-      name: snat
-    vars:
-      network_name: hostonly_dpdk
-      network_cidr: "{{ hostonly_dpdk_cidr }}"
-      public_ip: "{{ network_info.public_ipv4.address }}"
-    when:
-    - dpdk_interface is defined

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -146,22 +146,6 @@
     environment:
       OS_CLOUD: standalone
 
-  - name: Create hostonly-dpdk network # noqa 301
-    when: dpdk_interface is defined
-    shell: |
-      if ! openstack network show hostonly-dpdk; then
-          openstack network create --project openshift --share --external --provider-physical-network hostonly-dpdk --provider-network-type flat hostonly-dpdk
-      fi
-      if ! openstack subnet show hostonly-dpdk-subnet; then
-          openstack subnet create --project openshift hostonly-dpdk-subnet --subnet-range "{{ hostonly_dpdk_cidr }}" \
-              --dhcp --gateway "{{ hostonly_dpdk_gateway }}" \
-              --dns-nameserver "{{ network_info.dns | first }}" \
-              --allocation-pool "start={{ hostonly_dpdk_fip_pool_start }},end={{ hostonly_dpdk_fip_pool_end }}" \
-              --network hostonly-dpdk
-      fi
-    environment:
-      OS_CLOUD: standalone
-
   - name: Create basic security group which allow SSH # noqa 301
     shell: |
       if ! openstack security group show allow_ssh; then

--- a/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
+++ b/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
@@ -23,10 +23,13 @@ network_config:
   - destination: {{ hostonly_cidr }}
     nexthop: {{ hostonly_gateway }}
   members:
-  - type: interface
-    name: dummy1
-    nm_controlled: true
-    mtu: 1500
+  - type: ovs_dpdk_port
+    name: dpdk
+    rx_queue: 2
+    members:
+    - type: interface
+      name: {{ dpdk_interface }}
+      mtu: 9000
 {% if sriov_interface is defined %}
 - type: sriov_pf
   name: {{ sriov_interface }}
@@ -37,22 +40,4 @@ network_config:
   hotplug: true
   promisc: false
 {% endif %}
-- type: ovs_user_bridge
-  name: br-dpdk
-  use_dhcp: false
-  ovs_extra:
-  - br-set-external-id br-dpdk bridge-id br-dpdk
-  addresses:
-  - ip_netmask: {{ hostonly_dpdk_gateway }}/32
-  routes:
-  - destination: {{ hostonly_dpdk_cidr }}
-    nexthop: {{ hostonly_dpdk_gateway }}
-  members:
-  - type: ovs_dpdk_port
-    name: dpdk
-    rx_queue: 2
-    members:
-    - type: interface
-      name: {{ dpdk_interface }}
-      mtu: 9000
 {% endif %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -66,10 +66,6 @@ hostonly_fip_pool_end: "{{ hostonly_cidr | nthhost(-2) }}"
 hostonly_sriov_cidr: 192.168.26.0/24
 hostonly_sriov_fip_pool_start: "{{ hostonly_sriov_cidr | nthhost(2) }}"
 hostonly_sriov_fip_pool_end: "{{ hostonly_sriov_cidr | nthhost(-2) }}"
-hostonly_dpdk_cidr: 192.168.27.0/24
-hostonly_dpdk_gateway: "{{ hostonly_dpdk_cidr | nthhost(1) }}"
-hostonly_dpdk_fip_pool_start: "{{ hostonly_dpdk_cidr | nthhost(2) }}"
-hostonly_dpdk_fip_pool_end: "{{ hostonly_dpdk_cidr | nthhost(-2) }}"
 
 # Configuration used only by prepare_stack_testconfig, which is not run by
 # default.
@@ -102,7 +98,7 @@ low_memory_usage: false
 # This param can be overriden, but only when overriding the network_config, otherwise the default
 # should work as is:
 #neutron_bridge_mappings:
-neutron_flat_networks: "external,hostonly,hostonly-sriov,hostonly-dpdk"
+neutron_flat_networks: "external,hostonly,hostonly-sriov"
 
 tripleo_repos_repos:
   - current-tripleo


### PR DESCRIPTION
Re-use `hostonly` provider network when DPDK is enabled and instead of
adding a dummy interface (dummy1), just use the physical interface that
we want to use for DPDK.

This will avoid confusions when our users see multiple provider
networks.
In fact, one is enough and should be used.

Note: we maintain the SRIOV provider network separated, since it's using
another kind of interface etc.
