### PR TITLE
Wipe disk(s) used for ceph

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -219,7 +219,7 @@
         fstype: xfs
         state: mounted
 
-  - name: Prepare host for Ceph
+  - name: Prepare host for Ceph (loop device)
     when:
     - ceph_enabled
     - ceph_devices is not defined
@@ -270,6 +270,16 @@
         vg: vg_ceph
         lv: db
         size: 4%VG
+
+  - name: Prepare host for Ceph (disk device)
+    when:
+    - ceph_enabled
+    - ceph_devices is defined
+    block:
+    - name: Wipe filesystem from disk
+      command: wipefs -a "{{ item }}"
+      loop: "{{ ceph_devices }}"
+
   - name: Prepare kernel and reboot
     when:
     - kernel_args is defined

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -275,6 +275,8 @@
     when:
     - ceph_enabled
     - ceph_devices is defined
+    - ceph_devices is string
+    - (ceph_devices | length) > 0
     block:
     - name: Wipe filesystem from disk
       command: wipefs -a "{{ item }}"


### PR DESCRIPTION
If you don't do this, Ceph will moan about the presence of a bootloader. Use of `wipefs` is an alternative to using ceph-volume's `zap` command, which requires ceph be already installed on the host.