### PR TITLE
'ceph_devices' is a list, not a string

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -275,7 +275,7 @@
     when:
     - ceph_enabled
     - ceph_devices is defined
-    - ceph_devices is string
+    - ceph_devices is not true
     - (ceph_devices | length) > 0
     block:
     - name: Wipe filesystem from disk


### PR DESCRIPTION
We shouldn't be checking for a string. Just make sure it's not a boolean (used for OSP 17 or later)
