### PR TITLE
Fix osc install when running in a virtualenv

### DIFF
--- a/playbooks/local_os_client.yaml
+++ b/playbooks/local_os_client.yaml
@@ -120,7 +120,7 @@
   - name: Install openstack client locally
     pip:
       name: python-openstackclient
-      extra_args: --user
+      extra_args: "{% if not is_local_virtualenv %} --user {% endif %}"
 
   - name: Create the scripts if it does not exist
     ansible.builtin.file:

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -3,6 +3,9 @@ rhos_release: 16.2
 hostname: standalone
 clouddomain: shiftstack
 
+# is ansible running in a virtualenv on the control node
+is_local_virtualenv: "{{ lookup('env','VIRTUAL_ENV') | default('', true) }}"
+
 # The name of the cloud in *local* clouds.yaml. On the host it will always be
 # called `standalone`.
 local_cloudname: standalone


### PR DESCRIPTION
"--user" shouldn't be specified when installing
pip packages install a python virtualenv. Setting it causes
the following error:

TASK [Install openstack client locally] ****************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Unsupported parameters for (pip) module: when. Supported parameters include: virtualenv_site_packages, editable, executable, virtualenv, name, extra_args, virtualenv_command, virtualenv_python, state, umask, chdir, requirements, version."}