### PR TITLE
CentOS 9 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ dev-install requires that:
 * the machine running dev-install can SSH to the standalone host as either root or a user with passwordless sudo access
 * this machine has Ansible installed, and some dependencies like python3-netaddr.
 
-For OSP 16.2, the recommended OS is RHEL 8.4. For OSP 17, the recommended RHEL is 8.4 (it will not work on <8.3).
+For OSP 16.2, the recommended OS is RHEL 8.4. For OSP 17, the recommended RHEL will be 9.
 There is no need to do any other configuration prior to running dev-install.
 When deploying on TripleO from upstream, you need to deploy on CentOS Stream. If CentOS is not Stream, dev-install will migrate it.
 

--- a/example-overrides/local-overrides-centos9-tripleo-master.yaml
+++ b/example-overrides/local-overrides-centos9-tripleo-master.yaml
@@ -1,0 +1,8 @@
+standalone_host: <standalone FQDN>
+public_api: <IP address used to reach the node>
+tripleo_repos_repo_branch: master
+cip_config:
+  - set:
+      namespace: quay.io/tripleomastercentos9
+      name_prefix: openstack-
+      tag: current-tripleo

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -127,7 +127,7 @@
     vars:
       checkpoint: "{{ (nmstateset.stdout_lines|last).split()[1] }}"
 
-  # We have seen this creating a CentOS8 VM in OpenStack. We don't understand
+  # We have seen this creating a CentOS VM in OpenStack. We don't understand
   # why they are created. Specifically we see a phantom ens3 device. It's
   # possible they are baked into the image?
   #

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -107,6 +107,7 @@
   - name: Ensure that container-tools 3.0 is being used
     when:
       - ansible_facts.distribution == 'CentOS'
+      - ansible_facts.distribution_major_version == "8"
     shell: |
       dnf module disable -y container-tools:rhel8
       dnf module enable -y container-tools:3.0

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -167,7 +167,7 @@ kernel_services:
 #kernel_args:
 
 # This should not be changed unless you know what you're doing
-# because CentOS8 stream is now the only distro supported when deploying
+# because CentOS stream is now the only distro supported when deploying
 # TripleO from upstream.
 tripleo_repos_stream: true
 


### PR DESCRIPTION
* Update README
* Add example overrides for centos9 deployed on tripleo master
* Install modules only for 8 stream. No modules are required on 9
