### PR TITLE
install_stack: disable the use of --standalone arg in recent TripleO

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -465,13 +465,23 @@
     become: true
     become_user: root
 
+  - name: Block to figure out if --standalone needs to be passed when deploying tripleo
+    when:
+    - ansible_facts.distribution == 'CentOS'
+    block:
+      - name: Check if the version of TripleO is recent enough to remove --standalone argument
+        set_fact:
+          standalone_toggle: false
+        when:
+        - (tripleo_repos_branch is defined and tripleo_repos_branch not in ['train', 'ussuri', 'victoria']) or (tripleo_repos_branch is not defined)
+
   - name: Run TripleO deploy
     import_role:
       name: tripleo.operator.tripleo_deploy
     vars:
       openstack_bin: sudo openstack
       tripleo_deploy_deployment_user: stack
-      tripleo_deploy_standalone: true
+      tripleo_deploy_standalone: "{{ standalone_toggle | default(true) }}"
       tripleo_deploy_output_dir: "{{ ansible_env.HOME }}"
       tripleo_deploy_local_ip: "{{ local_ip }}"
       tripleo_deploy_control_virtual_ip: "{{ control_plane_ip }}"


### PR DESCRIPTION
Tripleoclient removed --standalone option some time ago:
https://review.opendev.org/c/openstack/python-tripleoclient/+/753447

And the TripleO Operator Ansible was updated to not use it anymore:
https://review.opendev.org/c/openstack/tripleo-operator-ansible/+/753853

In dev-install, we now figure out if the version of TripleO that is
being installed on CentOS needs or doesn't need that flag.

Note that we'll have to figure out how to make it work for OSP 17.1 and
OSP 18, since they'll probably contain these changes, but we have time
for now.
