### PR TITLE
Add a minimal local-overrides sample

### DIFF
--- a/example-overrides/local-overrides-basic.yaml
+++ b/example-overrides/local-overrides-basic.yaml
@@ -1,0 +1,13 @@
+# A sample local-overrides.yaml that configures a "basic" deployment.
+# The default services are enabled and an external network is created, allowing
+# for e.g. SSH access to guests. Note that IP addresses are clearly deployment
+# specific and should be updated to reflect your environment.
+standalone_host: openstack.example.com
+ceph_devices:
+  - /dev/sdb
+external_cidr: 10.1.10.2/24
+external_fip_pool_start: 10.1.10.100
+external_fip_pool_end: 10.1.10.104
+external_gateway: 10.1.10.254
+public_api: 10.1.240.48
+local_cloudname: example-cloud


### PR DESCRIPTION
While you can in theory use dev-install with the default local-overrides generated by 'make config', most people will want an external network and (most likely) a unique name for their cloud in 'clouds.yaml'. The existing local-overrides files focus on scenarios described in the "Advanced Features" section of the README but there is no example for sane, non-advanced configuration. Add one now, avoiding the need for me to relearn this this stuff each time I use dev-install
