### PR TITLE
net_config: don't override primary nic

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -1,9 +1,6 @@
 #vi:syntax=yaml
 ---
 network_config:
-{% if network_config is defined %}
-{{ network_config | to_nice_yaml }}
-{% else %}
 - type: ovs_bridge
   name: br-ex
   use_dhcp: true
@@ -14,6 +11,9 @@ network_config:
   - type: interface
     name: {{ network_info.public_ipv4.interface }}
     primary: true
+{% if network_config is defined %}
+{{ network_config | to_nice_yaml }}
+{% else %}
 - type: ovs_bridge
   name: br-ctlplane
   use_dhcp: false

--- a/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
+++ b/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
@@ -1,13 +1,13 @@
 #vi:syntax=yaml
 ---
 network_config:
-{% if network_config is defined %}
-{{ network_config | to_nice_yaml }}
-{% else %}
 - type: interface
   name: {{ network_info.public_ipv4.interface }}
   use_dhcp: true
   mtu: {{ network_info.public_ipv4.mtu }}
+{% if network_config is defined %}
+{{ network_config | to_nice_yaml }}
+{% else %}
 - type: interface
   name: dummy0
   use_dhcp: false


### PR DESCRIPTION
the primary nic should not be overriden because we have some mechanism
to find out which interface is used for public network.

let's just override all the rest but not the primary nic to avoid
complexity.
