### PR TITLE
IPv6 Dual Stack on hostonly network

### DIFF
--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -128,6 +128,12 @@
               --allocation-pool "start={{ hostonly_fip_pool_start }},end={{ hostonly_fip_pool_end }}" \
               --network hostonly
       fi
+      if ! openstack subnet show hostonly-subnet-v6; then
+          openstack subnet create --project openshift hostonly-subnet-v6 --subnet-range "{{ hostonly_v6_cidr }}" \
+              --dhcp --gateway "{{ hostonly_v6_gateway }}" \
+              --allocation-pool "start={{ hostonly_v6_fip_pool_start }},end={{ hostonly_v6_fip_pool_end }}" \
+              --network hostonly --ip-version 6 --ipv6-ra-mode dhcpv6-stateful --ipv6-address-mode dhcpv6-stateful
+      fi
     environment:
       OS_CLOUD: standalone
 
@@ -161,6 +167,7 @@
       if ! openstack security group show allow_ping; then
           openstack security group create allow_ping --project openshift
           openstack security group rule create --protocol icmp --project openshift allow_ping
+          openstack security group rule create --protocol ipv6-icmp --project openshift allow_ping
       fi
     environment:
       OS_CLOUD: standalone

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -41,6 +41,7 @@ network_config:
   - br-set-external-id br-hostonly bridge-id br-hostonly
   addresses:
   - ip_netmask: {{ hostonly_gateway }}/32
+  - ip_netmask: {{ hostonly_v6_gateway }}/64
   routes:
   - destination: {{ hostonly_cidr }}
     nexthop: {{ hostonly_gateway }}

--- a/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
+++ b/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
@@ -19,6 +19,7 @@ network_config:
   - br-set-external-id br-hostonly bridge-id br-hostonly
   addresses:
   - ip_netmask: {{ hostonly_gateway }}/32
+  - ip_netmask: {{ hostonly_v6_gateway }}/64
   routes:
   - destination: {{ hostonly_cidr }}
     nexthop: {{ hostonly_gateway }}

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -49,6 +49,12 @@ parameter_defaults:
 {% endfor %}
   # needed for vip & pacemaker
   KernelIpNonLocalBind: 1
+  # For OSP16
+  ExtraSysctlSettings:
+    net.ipv6.conf.all.forwarding:
+      value: 1
+  # For OSP17 and beyond
+  KernelIpv6ConfAllForwarding: 1
   DockerInsecureRegistryAddress:
     - {{ control_plane_ip }}:8787
   # domain name used by the host

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -53,7 +53,7 @@ external_gateway: "{{ network_info.public_ipv4.gateway }}"
 # external_fip_pool_start
 # external_fip_pool_end
 
-# The `hostonly` provider network
+# The `hostonly` dual-stack provider network
 # This will always be created. It creates a provider network which is local to
 # the host, and not externally routable.
 # The routable cidr of the hostonly network, even if we can't use all of it.
@@ -64,6 +64,11 @@ hostonly_gateway: "{{ hostonly_cidr | nthhost(1) }}"
 # The range of allocatable FIPs within hostonly_cidr
 hostonly_fip_pool_start: "{{ hostonly_cidr | nthhost(2) }}"
 hostonly_fip_pool_end: "{{ hostonly_cidr | nthhost(-2) }}"
+# Same for IPv6
+hostonly_v6_cidr: 2001:db8::/64
+hostonly_v6_gateway: "{{ hostonly_v6_cidr | nthhost(1) }}"
+hostonly_v6_fip_pool_start: "{{ hostonly_v6_cidr | nthhost(2) }}"
+hostonly_v6_fip_pool_end: "{{ hostonly_v6_cidr | nthhost(-2) }}"
 
 # `hostonly` variants
 hostonly_sriov_cidr: 192.168.26.0/24


### PR DESCRIPTION
From now, the `hostonly` network will be configured in dual stack so we
can easily play with IPv6 on that provider network.

We'll use 2001:db8::/64 cidr and make sure that we can create VMs on
that network, and ping from each other and even reach outside out of the
box.

Tested on OSP 16.2.
