### PR TITLE
Allow to override MTUs

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -4,13 +4,14 @@ network_config:
 - type: ovs_bridge
   name: br-ex
   use_dhcp: true
-  mtu: {{ network_info.public_ipv4.mtu }}
+  mtu: {{ public_mtu }}
   ovs_extra:
   - br-set-external-id br-ex bridge-id br-ex
   members:
   - type: interface
     name: {{ network_info.public_ipv4.interface }}
     primary: true
+    mtu: {{ public_mtu }}
 {% if network_config is defined %}
 {{ network_config | to_nice_yaml }}
 {% else %}
@@ -25,7 +26,7 @@ network_config:
   - type: interface
     name: dummy0
     nm_controlled: true
-    mtu: {{ dcn_az is defined | ternary(1400, 1500) }}
+    mtu: {{ dcn_az is defined | ternary(ctlplane_mtu, public_mtu) }}
 {% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-ctlplane-{{ ip | to_uuid }}"
@@ -57,7 +58,7 @@ network_config:
   - type: interface
     name: dummy1
     nm_controlled: true
-    mtu: {{ dcn_az is defined | ternary(1400, 1500) }}
+    mtu: {{ dcn_az is defined | ternary(hostonly_mtu, public_mtu) }}
 {% if sriov_interface is defined %}
 - type: sriov_pf
   name: {{ sriov_interface }}

--- a/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
+++ b/playbooks/templates/dev-install_net_config_dpdk.yaml.j2
@@ -4,7 +4,7 @@ network_config:
 - type: interface
   name: {{ network_info.public_ipv4.interface }}
   use_dhcp: true
-  mtu: {{ network_info.public_ipv4.mtu }}
+  mtu: {{ public_mtu }}
 {% if network_config is defined %}
 {{ network_config | to_nice_yaml }}
 {% else %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -229,4 +229,11 @@ ovn_enabled: true
 # over VXLAN. For PEK2 DSAL boxes you might need to bump that value to e.g.
 # 1350 as apprently there are packets flying with 1260 (and 1300 will give you
 # 1242 on Neutron network which won't be enough).
+# 
+# The default value can be problematic when doing double encapsulaiton with OVN,
+# the value will have to be increased. See the following bug report:
+# https://issues.redhat.com/browse/OCPBUGS-2921
 neutron_mtu: 1300
+ctlplane_mtu: "{{ neutron_mtu + 100 }}"
+hostonly_mtu: "{{ neutron_mtu + 100 }}"
+public_mtu: "{{ ctlplane_mtu + 100 }}"


### PR DESCRIPTION
* br-ex/public MTU default remains 1500, but is now overridable
* br-ctlplane/br-hostonly can be overridable and default is 1400
* Neutron MTU for tenant network remains 1300 by default but this needs
  to be bumped if double encapsulation is done with IPv6, see
  https://issues.redhat.com/browse/OCPBUGS-2921
