### PR TITLE
Fix MTU concatenation

### DIFF
--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -234,6 +234,6 @@ ovn_enabled: true
 # the value will have to be increased. See the following bug report:
 # https://issues.redhat.com/browse/OCPBUGS-2921
 neutron_mtu: 1300
-ctlplane_mtu: "{{ neutron_mtu + 100 }}"
-hostonly_mtu: "{{ neutron_mtu + 100 }}"
-public_mtu: "{{ ctlplane_mtu + 100 }}"
+ctlplane_mtu: "{{ neutron_mtu|int + 100 }}"
+hostonly_mtu: "{{ neutron_mtu|int + 100 }}"
+public_mtu: "{{ ctlplane_mtu|int + 100 }}"


### PR DESCRIPTION
This commit converts the mtu to int before concataneting, otherwise we would get the following error:

"Unexpected templating type error occurred on ({{ ctlplane_mtu + 100 }}): can only concatenate str (not \"int\") to str"}"