### PR TITLE
Increase default Neutron MTU

### DIFF
--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -235,15 +235,15 @@ ovn_enabled: true
 
 # In multinode, we create VXLAN tunnels to connect the br-ctlplane bridges
 # and on top of it, Neutron tenant networks will also have tunnels so
-# we need to lower the MTU to 1300 which should be safe to do Geneve tunnels
-# over VXLAN. For PEK2 DSAL boxes you might need to bump that value to e.g.
-# 1350 as apprently there are packets flying with 1260 (and 1300 will give you
+# we need to lower the MTU to 1400 which should be safe to do Geneve tunnels
+# over VXLAN. For PEK2 DSAL boxes you might need to have 1350 as apparently
+# there are packets flying with 1260 (and 1300 will give you
 # 1242 on Neutron network which won't be enough).
 # 
 # The default value can be problematic when doing double encapsulaiton with OVN,
 # the value will have to be increased. See the following bug report:
 # https://issues.redhat.com/browse/OCPBUGS-2921
-neutron_mtu: 1300
+neutron_mtu: 1400
 ctlplane_mtu: "{{ neutron_mtu|int + 100 }}"
 hostonly_mtu: "{{ neutron_mtu|int + 100 }}"
 public_mtu: "{{ ctlplane_mtu|int + 100 }}"


### PR DESCRIPTION
Due to a known issue with OVN-Kubernetes the default Neutron MTU should be at least 1400.