### PR TITLE
Allow to easily enable Barbican (with Simple Crypto)

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -327,6 +327,17 @@
             octavia_env:
               - /usr/share/openstack-tripleo-heat-templates/environments/services/octavia.yaml
 
+    - name: Enable Barbican
+      when: barbican_enabled
+      block:
+        - name: Add barbican to enabled services
+          ansible.builtin.set_fact:
+            service_envs: "{{ service_envs | union(barbican_env) }}"
+          vars:
+            barbican_env:
+              - /usr/share/openstack-tripleo-heat-templates/environments/services/barbican.yaml
+              - /usr/share/openstack-tripleo-heat-templates/environments/barbican-backend-simple-crypto.yaml
+
     - name: Generate container_image_prepare.yaml if not using rhos-release # noqa no-changed-when
       when:
         - cip_config is not defined

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -67,14 +67,14 @@
             - 2022
           register: rhca
 
-        - name: Add the certificate to the local trust bundle # noqa no-changed-when
+        - name: Add the certificate to the local trust bundle # noqa no-changed-when no-handler
           ansible.builtin.shell: |
             update-ca-trust enable
             update-ca-trust extract
           when: rhca.changed
 
         - name: Configure rhos release and keep puddle name for "{{ rhos_release }}" # noqa no-changed-when
-          ansible.builtin.shell: rhos-release "{{ rhos_release }}" | awk '/^# rhos-release/ { print $5 }'
+          ansible.builtin.command: rhos-release "{{ rhos_release }}" | awk '/^# rhos-release/ { print $5 }'
           register: rhos_release_puddle
 
         - name: Extract puddle name from rhos-release output

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -106,6 +106,7 @@ parameter_defaults:
   OctaviaCaKeyPassphrase: "secrete"
   OctaviaAmphoraSshKeyFile: "{{ ansible_env.HOME }}/octavia.pub"
   OctaviaAmphoraImageFilename: "{{ ansible_env.HOME }}/amphora.qcow2"
+  BarbicanSimpleCryptoGlobalDefault: true
   CinderApiPolicies:
     cinder-vol-state-set:
       key: "volume_extension:volume_admin_actions:reset_status"

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -139,6 +139,8 @@ ceph_loop_device_size: 100
 
 octavia_enabled: true
 
+barbican_enabled: false
+
 manila_enabled: false
 # Workaround for BZ#1969962
 manila_services:


### PR DESCRIPTION
Allow to easily install Barbican with the simple crypto plugin.

This is opinionated but can easily be overridden.

NOTE: this PR also fixes a few lint errors.