### PR TITLE
Add `public_default_route` to allow applying default route

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -12,6 +12,11 @@ network_config:
     name: {{ network_info.public_ipv4.interface }}
     primary: true
     mtu: {{ public_mtu }}
+{% if public_default_route %}
+  routes:
+  - default: true
+    next_hop: {{ network_info.public_ipv4.gateway }}
+{% endif %}
 {% if network_config is defined %}
 {{ network_config | to_nice_yaml }}
 {% else %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -32,6 +32,9 @@ control_plane_ip: "{{ control_plane_cidr | nthhost(2) }}"
 # By default we use the default IP of the host
 public_api: "{{ network_info.public_ipv4.address }}"
 
+# Whether or not manually create the default route via br-ex, in case it's not applicable via DHCP.
+public_default_route: false
+
 # For advanced network configurations (e.g. SR-IOV), network_config can be overriden
 # The format is for os-net-config, check dev-install_net_config.yaml.j2 template.
 # network_config


### PR DESCRIPTION
Sometimes, the default route can't be applied on br-ex via DHCP for some
reasons, and it can be useful to add this route manually before
os-net-config is creating the br-ex bridge. It'll avoid networking
issues.

This feature is disabled by default for backward compability.
