### PR TITLE
CinderApiPolicies: allow force-detach

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -111,6 +111,9 @@ parameter_defaults:
     cinder-vol-state-set:
       key: "volume_extension:volume_admin_actions:reset_status"
       value: "rule:admin_or_owner"
+    cinder-vol-force-detach:
+      key: "volume_extension:volume_admin_actions:force_detach"
+      value: "rule:admin_or_owner"
   # We never want the node to reboot during tripleo deploy, but defer to later
   KernelArgsDeferReboot: true
   StandaloneExtraGroupVars:


### PR DESCRIPTION
We have observed in our CI that sometimes volumes aren't detached when
being removed.
This can be due to the density of testing in our environment.
To address this, we allow tenants to force-detach their own volumes.

In our CI scripts, we'll use that to force detach volumes before they
are cleaned-up in the periodic cleanup jobs.
