### PR TITLE
Updated support for rhsm builds of rhosp17 on rhel9

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ dev-install installs [TripleO standalone](https://docs.openstack.org/project-dep
 dev-install requires that:
 * an appropriate OS has already been installed
 * the machine running dev-install can SSH to the standalone host as either root or a user with passwordless sudo access
-* this machine has Ansible installed, and some dependencies like python3-netaddr.
+* this machine has Ansible installed, and some dependencies like python3-netaddr, python3-jmespath, python3-openstackclient.
 
-For OSP 16.2, the recommended OS is RHEL 8.4. For OSP 17, the recommended RHEL will be 9.
+For OSP 16.2, the recommended OS is RHEL 8.4. For OSP 17.0, the required RHEL will be 9.0.
 There is no need to do any other configuration prior to running dev-install.
 When deploying on TripleO from upstream, you need to deploy on CentOS Stream. If CentOS is not Stream, dev-install will migrate it.
 

--- a/example-overrides/local-overrides-osp17-0.yaml
+++ b/example-overrides/local-overrides-osp17-0.yaml
@@ -1,0 +1,67 @@
+# Override default variables by putting them in this file
+standalone_host: 192.168.124.131
+public_api: 192.168.124.131
+rhos_release: 17.0
+hostname: rhos-17
+clouddomain: home.lan
+local_cloudname: rhos-17
+openshift_password: openshift
+ceph_devices:
+  - /dev/sda
+rhsm_release: 9.0
+rhsm_repos:
+  - rhel-9-for-x86_64-baseos-eus-rpms
+  - rhel-9-for-x86_64-appstream-eus-rpms
+  - rhel-9-for-x86_64-highavailability-eus-rpms
+  - openstack-17-for-rhel-9-x86_64-rpms
+  - fast-datapath-for-rhel-9-x86_64-rpms
+  - rhceph-5-tools-for-rhel-9-x86_64-rpms
+rhsm_enabled: true
+# Get your organization ID and create your activation key at:
+# https://console.redhat.com/settings/connector/activation-keys
+rhsm_org_id: replace-with-numeric-org-id
+rhsm_activation_key: replace-with-org-activation-key
+
+# rhcs5 installation doesnt seem to play well with redhat registry service accounts
+# due to the mandatory pipe character in the username it issues.
+#
+# the workaround is to configure root podman directly at the url below
+#
+# https://access.redhat.com/terms-based-registry/#/accounts
+#
+# You can also create service accounts for redhat_registry_credentials here as well
+registry_auth_file: "/home/greg/dev-install/config.json"
+
+redhat_registry_credentials:
+    'numeric-org-id|service-account-name': 'long-password-data-string'
+
+cip_config:
+  - set:
+      ceph_alertmanager_image: ose-prometheus-alertmanager
+      ceph_alertmanager_namespace: registry.redhat.io/openshift4
+      ceph_alertmanager_tag: 4.6
+      ceph_grafana_image: rhceph-5-dashboard-rhel8
+      ceph_grafana_namespace: registry.redhat.io/rhceph
+      ceph_grafana_tag: latest
+      ceph_image: rhceph-5-rhel8
+      ceph_namespace: registry.redhat.io/rhceph
+      ceph_node_exporter_image: ose-prometheus-node-exporter
+      ceph_node_exporter_namespace: registry.redhat.io/openshift4
+      ceph_node_exporter_tag: v4.6
+      ceph_prometheus_image: ose-prometheus
+      ceph_prometheus_namespace: registry.redhat.io/openshift4
+      ceph_prometheus_tag: 4.6
+      ceph_tag: latest
+      name_prefix: openstack-
+      name_suffix: ''
+      namespace: registry.redhat.io/rhosp-rhel9
+      neutron_driver: ovn
+      rhel_containers: false
+      tag: '17.0'
+    tag_from_label: '{version}-{release}'
+
+
+# fix for the following bug:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1498621
+extra_heat_params:
+  NovaComputeStartupDelay: 0

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -388,7 +388,10 @@
     #
     # Therefore it is easier to use the config.json method for podman.
     - name: Setup Docker registry authentication
-      when: cip_config is defined
+      when:
+        - cip_config is defined
+        - rhsm_enabled is defined
+        - registry_auth_file is defined
       become: true
       become_user: root
       block:

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -389,9 +389,11 @@
     # Therefore it is easier to use the config.json method for podman.
     - name: Setup Docker registry authentication
       when: cip_config is defined
+      become: true
+      become_user: root
       block:
         - name: Ensure the .docker directory exists
-          file:
+          ansible.builtin.file:
             path: "/root/.docker"
             state: directory
             mode: '0755'
@@ -399,14 +401,12 @@
             group: "root"
 
         - name: Copy config.json to remote host
-          copy:
+          ansible.builtin.copy:
             src: "{{ registry_auth_file }}"
             dest: "/root/.docker/config.json"
             owner: "root"
             group: "root"
             mode: '0644'
-      become: true
-      become_user: root
 
     - name: Download containers-prepare-parameters.yaml from upstream master if cip_config is not defined on CentOS
       when:

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -380,6 +380,33 @@
         cip_content:
           parameter_defaults:
             ContainerImagePrepare: "{{ cip_config }}"
+            ContainerImageRegistryLogin: true
+
+    # Red Hat Service Accounts have fixed usernames that incorporate a pipe character
+    # there is a lot of work required to handle this vs. a straight username because of to_nice_yaml
+    # when the rhcs5 portion of the build is started.
+    #
+    # Therefore it is easier to use the config.json method for podman.
+    - name: Setup Docker registry authentication
+      when: cip_config is defined
+      block:
+        - name: Ensure the .docker directory exists
+          file:
+            path: "/root/.docker"
+            state: directory
+            mode: '0755'
+            owner: "root"
+            group: "root"
+
+        - name: Copy config.json to remote host
+          copy:
+            src: "{{ registry_auth_file }}"
+            dest: "/root/.docker/config.json"
+            owner: "root"
+            group: "root"
+            mode: '0644'
+      become: true
+      become_user: root
 
     - name: Download containers-prepare-parameters.yaml from upstream master if cip_config is not defined on CentOS
       when:

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -113,7 +113,7 @@
         stdin: "{{ network_state | to_nice_json }}"
       vars:
         network_state:
-          interfaces: "{{ nmstate_ifs }}"
+          interfaces: "{{ nmstate_ifs | from_yaml }}"
           # add saved static routes
           routes:
             config: "{{ nmstate_routes }}"
@@ -125,11 +125,11 @@
       ansible.builtin.set_fact:
         checkpoint: "{{ (nmstateset.stdout_lines | last).split()[1] }}"
 
-    - name: Set fact for nmstate checkpoing on RHEL9
+    - name: Set fact for nmstate checkpoint on RHEL9
       when:
         - ansible_facts.distribution_major_version == "9"
       ansible.builtin.set_fact:
-        checkpoint: "{{ (nmstateset.stderr_lines | last).split()[-1] }}"
+        checkpoint: "{{ (nmstateset.stdout_lines | select('search', 'Checkpoint: NetworkManager\\|') | last).split()[1] }}"
 
     - name: Fail if the checkpoint has not been found or is incorrect
       when:

--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -125,11 +125,19 @@
       ansible.builtin.set_fact:
         checkpoint: "{{ (nmstateset.stdout_lines | last).split()[1] }}"
 
-    - name: Set fact for nmstate checkpoint on RHEL9
+    - name: Set fact for nmstate checkpoint on RHEL9.0 for rhos-17.0 (stdout_lines)
       when:
         - ansible_facts.distribution_major_version == "9"
+        - ansible_distribution_version == "9.0"
       ansible.builtin.set_fact:
         checkpoint: "{{ (nmstateset.stdout_lines | select('search', 'Checkpoint: NetworkManager\\|') | last).split()[1] }}"
+
+    - name: Set fact for nmstate checkpoint on RHEL9.2+ for >rhos-17.0 (stderr_lines)
+      when:
+        - ansible_facts.distribution_major_version == "9"
+        - ansible_distribution_version == "9.2"
+      ansible.builtin.set_fact:
+        checkpoint: "{{ (nmstateset.stderr_lines | last).split()[-1] }}"
 
     - name: Fail if the checkpoint has not been found or is incorrect
       when:

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -37,14 +37,19 @@
         - name: Configure Red Hat Subscription Manager
           ansible.builtin.import_role:
             name: redhat-subscription
+        # this needs to be done early
+        - name: set rhsm_release
+          shell: subscription-manager release --set={{rhsm_release}}
         - name: Install container-tools module # noqa no-changed-when
           ansible.builtin.shell: |
             dnf module disable -y container-tools:rhel8
             dnf module enable -y container-tools:"{{ rhsm_container_tools_version }}"
+          when: rhsm_release | float < 9.0
         - name: Install virt module # noqa no-changed-when
           ansible.builtin.shell: |
             dnf module disable -y virt:rhel
             dnf module enable -y virt:"{{ virt_release }}"
+          when: rhsm_release | float < 9.0
 
     - name: Prepare host on RHEL system with rhos-release
       when:

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -37,19 +37,16 @@
         - name: Configure Red Hat Subscription Manager
           ansible.builtin.import_role:
             name: redhat-subscription
-        # this needs to be done early
-        - name: set rhsm_release
-          shell: subscription-manager release --set={{rhsm_release}}
         - name: Install container-tools module # noqa no-changed-when
           ansible.builtin.shell: |
             dnf module disable -y container-tools:rhel8
             dnf module enable -y container-tools:"{{ rhsm_container_tools_version }}"
-          when: rhsm_release | float < 9.0
+          when: ansible_distribution_major_version | int < 9
         - name: Install virt module # noqa no-changed-when
           ansible.builtin.shell: |
             dnf module disable -y virt:rhel
             dnf module enable -y virt:"{{ virt_release }}"
-          when: rhsm_release | float < 9.0
+          when: ansible_distribution_major_version | int < 9
 
     - name: Prepare host on RHEL system with rhos-release
       when:


### PR DESCRIPTION
Updated support for doing rhsm_enabled builds against official RHEL9/RHOS with registry.redhat.io
Added fixes for using service accounts via the terms based registry on access.redhat.com
Misc fixes for deploying virtually in libvirt/kvm
Provided an example local-overrides for rhos17 on rhel9 with details on creating the required components.