### PR TITLE
Skip `var-naming[no-role-prefix]` ansible-lint test

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -22,3 +22,7 @@ mock_roles:
   - redhat-subscription
   - tripleo.operator.tripleo_deploy
   - tripleo.operator.tripleo_repos
+
+skip_list:
+  # Variables names from within roles should use role_name_ as a prefix
+  - var-naming[no-role-prefix]


### PR DESCRIPTION
These errors are not important to us.
