### PR TITLE
Use nobest option when upgrading all packages

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -159,6 +159,7 @@
       ansible.builtin.yum:
         name: '*'
         state: latest
+        nobest: True
 
     - name: Reboot the node when necessary
       when:


### PR DESCRIPTION
This fixes the following error that I saw:

TASK [Upgrade all packages]
*************************************************************************************************************************** fatal: [standalone]: FAILED! => {"changed": false, "failures": [], "msg": "Depsolve Error occurred: \n Problem: package crypto-policies-scripts-2021111
6-1.gitae470d6.el8.noarch requires crypto-policies = 20211116-1.gitae470d6.el8, but none of the providers can be installed\n
- cannot install the best update candidate for package crypto-policies-scripts-20210209-1.gitbfb6bed.el8_3.noarch\n  - package crypto-policies-20211116-1.gitae470d6.el8.noarch
is filtered out by exclude filtering", "rc": 1, "results": []}