### PR TITLE
Package installation fixes

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -292,6 +292,13 @@
           ansible.builtin.set_fact:
             neutron_bridge_mappings: "{{ base_bridge_mappings }}"
 
+    - name: Downgrade leatherman as workaround for https://bugs.launchpad.net/tripleo/+bug/1845274
+      ansible.builtin.dnf:
+        name: 'leatherman-1.4.5-6.el8ost.1'
+        allow_downgrade: true
+      become: true
+      become_user: root
+
     - name: Create standalone_parameters.yaml
       no_log: true
       ansible.builtin.template:

--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -156,9 +156,10 @@
         state: installed
 
     - name: Upgrade all packages # noqa package-latest
-      ansible.builtin.yum:
+      ansible.builtin.dnf:
         name: '*'
         state: latest
+        nobest: true
 
     - name: Reboot the node when necessary
       when:


### PR DESCRIPTION
- Work around error using nobest option: "Depsolve Error occurred: \n Problem: package
crypto-policies-scripts-20211116-1.gitae470d6.el8.noarch requires crypto-policies = 20211116-1.gitae470d6.el8, but none of the providers can be installed\n  - cannot install the best update candidate for package crypto-policies-scripts-20210209-1.gitbfb6bed.el8_3.noarch\n  - package crypto-policies-20211116-1.gitae470d6.el8.noarch is filtered out by exclude filtering"
- Add workaround for https://bugs.launchpad.net/tripleo/+bug/1845274