### PR TITLE
network: enable the dummy interfaces

### DIFF
--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -40,16 +40,16 @@
             type: dummy
             state: up
             ipv4:
-              enabled: false
+              enabled: true
             ipv6:
-              enabled: false
+              enabled: true
           - name: dummy1
             type: dummy
             state: up
             ipv4:
-              enabled: false
+              enabled: true
             ipv6:
-              enabled: false
+              enabled: true
 
     - name: Define dummy interfaces to be created when using DPDK
       when:
@@ -65,7 +65,7 @@
                 - ip: {{ local_ip }}
                   prefix-length: {{ control_plane_prefix | int }}
             ipv6:
-              enabled: false
+              enabled: true
 
     # this saves the static route configuration including the default route
     # prior to filtering later


### PR DESCRIPTION
The dummy interfaces should be enabled if they have received a desired
route to a next hop.

This would avoid this kind of error:

```
NmstateError: InvalidArgument: The next hop interface of desired Route 'destination: 169.254.0.0/16 next-hop-interface: dummy0 next-hop-address: 0.0.0.0 metric: 1006 table-id: 254' has been marked as IPv4 disabled
```
