### PR TITLE
prepare_host: fix inconsistent nic naming on RHEL 9

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -22,7 +22,7 @@
     - name: Make sure persistent NIC names is not disabled # noqa no-changed-when
       ansible.builtin.shell: |
         if grep -q net.ifnames=0 /etc/default/grub; then
-            sed -i 's/net.ifnames=0 //g' /etc/default/grub
+            sed -i 's/net.ifnames=0//g' /etc/default/grub
             for f in grub2 grub2-efi; do
                 grub2-mkconfig -o $(readlink -f /etc/$f.cfg)
             done


### PR DESCRIPTION
Sometimes the `net.ifnames=0` is the last item in the default grub
arguments so the grep that was setup initially wouldn't match.

Let's just match `net.ifnames=0` and remove it.
