### PR TITLE
network: Add primary_nic_state parameter and if condition to setup br-ex

### DIFF
--- a/playbooks/network.yaml
+++ b/playbooks/network.yaml
@@ -101,7 +101,7 @@
       vars:
         primary_nic: "{{ [network_info.public_ipv4.interface] }}"
         removed:
-          state: absent
+          state: "{{ primary_nic_state }}"
 
     - name: Log target nmstate
       ansible.builtin.debug:

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -1,6 +1,7 @@
 #vi:syntax=yaml
 ---
 network_config:
+{% if external_fip_pool_start is defined %}
 - type: ovs_bridge
   name: br-ex
   use_dhcp: true
@@ -16,6 +17,7 @@ network_config:
   routes:
   - default: true
     next_hop: {{ network_info.public_ipv4.gateway }}
+{% endif %}
 {% endif %}
 {% if network_config is defined %}
 {{ network_config | to_nice_yaml }}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -35,6 +35,11 @@ public_api: "{{ network_info.public_ipv4.address }}"
 # Whether or not manually create the default route via br-ex, in case it's not applicable via DHCP.
 public_default_route: false
 
+# You can ensure the primary_nic won't be modified if primary_nic_state is set to 'up'.
+# It could be useful if a bond interface is provided by baremetal provider and
+# should not be modified during network setup.
+primary_nic_state: "absent"
+
 # For advanced network configurations (e.g. SR-IOV), network_config can be overriden
 # The format is for os-net-config, check dev-install_net_config.yaml.j2 template.
 # network_config


### PR DESCRIPTION
This parameter allow user to specify the primary state for the primary nic, this could be useful to deploy on a baremetal server where bonding (like lacp) is already configured and should not be modified.