### PR TITLE
RHSM: clone from latest commit

### DIFF
--- a/playbooks/roles/rhsm/tasks/main.yaml
+++ b/playbooks/roles/rhsm/tasks/main.yaml
@@ -13,4 +13,5 @@
     dest: ~/.ansible/roles/redhat-subscription
     repo: https://opendev.org/openstack/ansible-role-redhat-subscription
     update: "{{ update_rhsm | bool }}"
-    version: master
+    # Upstream repo has been retired, this is the latest commit
+    version: eefe5019238a7b88bda0a9df1a6d9b02267e4902


### PR DESCRIPTION
The repo was also retired, I'm trying to undo this but in the meantime
let's checkout from latest known commit.
