### PR TITLE
ssl: allow cert to be used by hostonly IPs

### DIFF
--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -81,6 +81,8 @@
       - "DNS:{{ standalone_host }}"
       - "IP:{{ public_api }}"
       - "IP:{{ control_plane_ip }}"
+      - "IP:{{ hostonly_gateway }}"
+      - "IP:{{ hostonly_v6_gateway }}"
   register: user_csr
 
 - name: Sign the CSR for {{ cert_user }}


### PR DESCRIPTION
In certain cases, we want to proxify endpoints through the hostonly
interfaces (ipv4 and ipv6) so let's relax the certificate and allow the
endpoints to be on these IPs too.
