### PR TITLE
Using registry credentials is now mandatory.

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -27,3 +27,6 @@ mock_roles:
 skip_list:
   # Variables names from within roles should use role_name_ as a prefix
   - var-naming[no-role-prefix]
+  - key-order[play]
+  - fqcn[action-core]
+  - var-naming[no-reserved]

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,14 +2,22 @@ name: Ansible Lint
 on:
   pull_request:
     paths:
-    - playbooks/**.yaml
+      - playbooks/**.yaml
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - name: checks-out the repository under $GITHUB_WORKSPACE
-      uses: actions/checkout@v3
-    - name: run ansible-lint
-      uses: ansible/ansible-lint-action@main
-      with:
-        path: playbooks/
+
+      - name: Checks-out the repository under $GITHUB_WORKSPACE
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install ansible-lint
+        run: python3 -m pip install ansible-dev-tools --user
+
+      - name: Install dependency
+        run: ansible-galaxy collection install -r requirements.yaml
+
+      - name: Run lint
+        run: ansible-lint playbooks/**

--- a/README.md
+++ b/README.md
@@ -33,6 +33,22 @@ At present the deployment depends on a valid DHCP source for the external interf
 
 All other requirements should be configured automatically by Ansible. Note that `dev-install` does require root access (or passwordless sudo) on the machine it is invoked from to install certificate management tools (simpleca) in addition to the remote host.
 
+## Defining registry
+
+Recently, there were changed way for accessing RedHat registry. Now it's mandatory to provide credentials to `local-override.yaml` file in a form of a list:
+
+```yaml
+registers:
+  - name: registry1.url
+    username: joe
+    password: secret
+  - name: registry2.url
+    username: alice
+    password: supersecret
+```
+
+RedHat registry, is expected to be the first one.
+
 ## Running dev-install
 
 `dev-install` is invoked using its `Makefile`. The simplest invocation is:

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -151,6 +151,20 @@
           become_user: root
           ansible.builtin.command: update-ca-trust extract
 
+    - name: Login into registries
+      become: true
+      become_user: root
+      when:
+        - registers is defined
+        - (registers | length) > 0
+      block:
+        - name: Login to registry
+          containers.podman.podman_login:
+            username: "{{ item.username | ansible.builtin.mandatory }}"
+            password: "{{ item.password | ansible.builtin.mandatory }}"
+            registry: "{{ item.name }}"
+          loop: "{{ registers }}"
+
     - name: Install the tripleo client
       ansible.builtin.yum:
         name: python3-tripleoclient

--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -535,7 +535,7 @@
         - sriov_interface is defined or dpdk_interface is defined or kernel_args is defined
       block:
         - name: Reboot the node
-          become_user: root
+          become: true
           ansible.builtin.reboot:
         - name: Pause for 2 minutes to let all containers to start and OpenStack to be ready
           ansible.builtin.pause:

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -1,4 +1,5 @@
 ---
+
 - hosts: standalone
   become: true
   become_user: stack

--- a/playbooks/prepare_stack.yaml
+++ b/playbooks/prepare_stack.yaml
@@ -1,5 +1,4 @@
 ---
-
 - hosts: standalone
   become: true
   become_user: stack

--- a/playbooks/roles/ceph/tasks/main.yaml
+++ b/playbooks/roles/ceph/tasks/main.yaml
@@ -16,18 +16,6 @@
         containers_prep: "{{ ansible_env.HOME }}/containers-prepare-parameters.yaml"
         deployed_ceph: "{{ ansible_env.HOME }}/deployed_ceph.yaml"
 
-    - name: Login into registry.redhat.io
-      become: true
-      become_user: root
-      when:
-        - rhsm_enabled
-      block:
-        - name: Login to registry.redhat.io
-          containers.podman.podman_login:
-            username: "{{ redhat_registry_credentials.username | ansible.builtin.mandatory }}"
-            password: "{{ redhat_registry_credentials.password | ansible.builtin.mandatory }}"
-            registry: registry.redhat.io
-
     - name: Configure Storage Network
       ansible.builtin.include_tasks: storage-network.yml
       vars:

--- a/playbooks/roles/operators/tasks/main.yaml
+++ b/playbooks/roles/operators/tasks/main.yaml
@@ -1,6 +1,19 @@
 ---
 # Install tripleo-operator in current user environment
 # and provide plugins and roles to local ansible env.
+- name: Ensure there are credentials for accessing registry
+  tags:
+    - always
+    - lab
+  ansible.builtin.assert:
+    that:
+      - registers is defined
+      - (registers|length) > 0
+      - registers.0.name is defined
+      - registers.0.username is defined
+      - registers.0.password is defined
+    msg: "It is expected to have defined at least one registry"
+
 - name: Ensure we have ~/.ansible
   tags:
     - always

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -144,8 +144,9 @@ parameter_defaults:
   NtpServer: {{ ntp_server }}
 {% endif %}
   ContainerImageRegistryCredentials:
-    registry.redhat.io:
-      {{ redhat_registry_credentials.username | ansible.builtin.mandatory | ansible.builtin.quote }}: {{ redhat_registry_credentials.password | ansible.builtin.mandatory | ansible.builtin.quote }}
+    # assume first registry
+    {{ registers.0.name | ansible.builtin.mandatory}}:
+      {{ registers.0.username | ansible.builtin.mandatory | ansible.builtin.quote }}: {{ registers.0.password | ansible.builtin.mandatory | ansible.builtin.quote }}
   ContainerImageRegistryLogin: true
 {% endif %}
 {% if ssl_enabled %}

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -229,10 +229,12 @@ rhsm_container_tools_version: '3.0'
 # Note: to install 16.1 on RHEL 8.2, you need virt_release set to "8.2"
 # For OSP 16.2 on RHEL 8.4, you need "av".
 virt_release: av
-# Red Hat Registry credentials have to be set when deploying OSP on RHEL
-# redhat_registry_credentials:
-#   username: joe
-#   password: secrete
+# Red Hat Registry credentials have to be set when deploying OSP on RHEL. Main
+# registry, and all additional one should be defined in a list:
+# registers:
+#   - name: registry.url
+#     username: joe
+#     password: secret
 
 # Edge parameters
 # The central site must be named "central", otherwise for other AZs it's up to the user.

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,0 +1,6 @@
+collections:
+  - ansible.posix
+  - community.general
+  - tripleo.operator
+  - containers.podman
+  - community.crypto


### PR DESCRIPTION
From now on, to have working deployment, you'll need credentials for the registry with images for ceph and tripleo.