### PR TITLE
Generate Python 3.13+ compatible certs

### DIFF
--- a/playbooks/roles/simpleca/tasks/main.yaml
+++ b/playbooks/roles/simpleca/tasks/main.yaml
@@ -31,6 +31,11 @@
         common_name: "simpleca"
         basic_constraints:
           - "CA:TRUE"
+        basic_constraints_critical: true
+        key_usage:
+          - keyCertSign
+          - cRLSign
+        key_usage_critical: true
       register: ca_csr
 
     - name: Sign the CA CSR
@@ -83,6 +88,12 @@
       - "IP:{{ control_plane_ip }}"
       - "IP:{{ hostonly_gateway }}"
       - "IP:{{ hostonly_v6_gateway }}"
+    key_usage:
+      - digitalSignature
+      - keyEncipherment
+    key_usage_critical: true
+    extended_key_usage:
+      - serverAuth
   register: user_csr
 
 - name: Sign the CSR for {{ cert_user }}


### PR DESCRIPTION
Python 3.13 tightened SSL cert validation requirements [1][1] which requires changes to how we generate our CA and server CSRs [2][2].

Once merged, we will need to regenerate certs on existing hosts.

[1]: https://docs.python.org/3/whatsnew/3.13.html#ssl
[2]: https://galaxy.ansible.com/ui/repo/published/community/crypto/content/module/openssl_csr/
