### PR TITLE
Fix container registry credentials not passed when rhsm is disabled

### DIFF
--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -143,6 +143,8 @@ parameter_defaults:
 {% if ntp_server is defined %}
   NtpServer: {{ ntp_server }}
 {% endif %}
+{% endif %}
+{% if registers is defined and registers | length > 0 %}
   ContainerImageRegistryCredentials:
     # assume first registry
     {{ registers.0.name | ansible.builtin.mandatory}}:


### PR DESCRIPTION
ContainerImageRegistryCredentials and ContainerImageRegistryLogin were gated behind {% if rhsm_enabled %}, so when using the rhos-release path they were never rendered into standalone_parameters.yaml. This caused TripleO to fail pulling container images with an authentication error, even though podman login succeeded separately.

Decouple the credentials block from rhsm_enabled and gate it on registers being defined instead, so credentials are passed to TripleO whenever registries are configured regardless of subscription method.