### PR TITLE
Fix reboot task to escalate as root instead of stack

### DIFF
--- a/playbooks/install_stack.yaml
+++ b/playbooks/install_stack.yaml
@@ -550,6 +550,7 @@
       block:
         - name: Reboot the node
           become: true
+          become_user: root
           ansible.builtin.reboot:
         - name: Pause for 2 minutes to let all containers to start and OpenStack to be ready
           ansible.builtin.pause:


### PR DESCRIPTION
The reboot task had become: true but inherited become_user: stack from the play level, causing 'Interactive authentication required' from polkit/systemd. Add become_user: root to match the pattern used by all other root-privileged tasks in the playbook.