### PR TITLE
Fix Ceph OSD not starting after reboot with loop device

### DIFF
--- a/playbooks/prepare_host.yaml
+++ b/playbooks/prepare_host.yaml
@@ -249,9 +249,11 @@
               [Unit]
               Description=Ceph OSD losetup
               After=syslog.target
+              Before=ceph.target
               [Service]
               Type=oneshot
               ExecStart=/bin/bash -c '/sbin/losetup /dev/loop1 || /sbin/losetup --direct-io=on /dev/loop1 /var/lib/ceph-osd.img'
+              ExecStartPost=/sbin/vgchange -ay vg_ceph
               ExecStop=/sbin/losetup -d /dev/loop1
               RemainAfterExit=yes
               [Install]


### PR DESCRIPTION
The ceph-osd-losetup service sets up the loop device backing the Ceph OSD, but after a reboot two things can go wrong:

1. LVM scans run before the loop device is ready, so the vg_ceph logical volumes (data, db) are never activated. The OSD fails with: 'failed to open /dev/vg_ceph/data: No such file or directory'

2. Ceph services can start before the losetup service completes, racing against the loop device setup.

Fix both by adding:
- ExecStartPost=vgchange -ay vg_ceph to activate the LVs after the loop device is attached
- Before=ceph.target to ensure correct ordering with all Ceph daemons