### PR TITLE
net_config: drop MTU from dummy interfaces

### DIFF
--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -31,7 +31,6 @@ network_config:
   - type: interface
     name: dummy0
     nm_controlled: true
-    mtu: {{ dcn_az is defined | ternary(ctlplane_mtu, public_mtu) }}
 {% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-ctlplane-{{ ip | to_uuid }}"
@@ -63,7 +62,6 @@ network_config:
   - type: interface
     name: dummy1
     nm_controlled: true
-    mtu: {{ dcn_az is defined | ternary(hostonly_mtu, public_mtu) }}
 {% if sriov_interface is defined %}
 - type: sriov_pf
   name: {{ sriov_interface }}


### PR DESCRIPTION
os-net-config validates the requested MTU against the kernel-reported max_mtu. Dummy interfaces report max_mtu=0 (meaning 'no limit'), but os-net-config treats 0 literally and rejects any MTU setting:

  dummy0 Desired MTU 1500 is greater than supported 0

Fix by removing the explicit mtu from the dummy0 and dummy1 bridge members. The OVS bridge handles MTU independently; dummy interfaces used as placeholder bridge members don't need it.