### PR TITLE
Add configuration flexibility for network and MTU settings

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -19,5 +19,10 @@ jobs:
       - name: Install dependency
         run: ansible-galaxy collection install -r requirements.yaml
 
+      # This works around the lint error from `ansible-playbook --syntax-check -vv playbooks/install_stack.yaml`
+      # [ERROR]: Could not find specified file in role, its 'tasks/' is not usable.
+      - name: Prepare redhat-subscription
+        run: git clone --depth 1 --branch 1.3.0 https://opendev.org/openstack/ansible-role-redhat-subscription.git $HOME/.ansible/roles/redhat-subscription
+
       - name: Run lint
-        run: ansible-lint playbooks/**
+        run: export ANSIBLE_COLLECTIONS_PATH=$HOME/.ansible/collections; ansible-lint playbooks/**

--- a/playbooks/prepare_stack_testconfig.yaml
+++ b/playbooks/prepare_stack_testconfig.yaml
@@ -56,7 +56,7 @@
         # Create a router for private<->external
         if ! openstack router show private-subnet-external >/dev/null; then
             openstack router create private-subnet-external
-            openstack router set private-subnet-external --external-gateway external
+            openstack router set private-subnet-external --external-gateway {{ external_network }}
             openstack router add subnet private-subnet-external private-subnet
         fi
       environment:

--- a/playbooks/templates/dev-install_net_config.yaml.j2
+++ b/playbooks/templates/dev-install_net_config.yaml.j2
@@ -31,7 +31,9 @@ network_config:
   - type: interface
     name: dummy0
     nm_controlled: true
+{% if enable_dummy_mtu %}
     mtu: {{ dcn_az is defined | ternary(ctlplane_mtu, public_mtu) }}
+{% end %}
 {% for ip in tunnel_remote_ips %}
   - type: ovs_tunnel
     name: "tun-ctlplane-{{ ip | to_uuid }}"
@@ -63,7 +65,9 @@ network_config:
   - type: interface
     name: dummy1
     nm_controlled: true
+{% if enable_dummy_mtu %}
     mtu: {{ dcn_az is defined | ternary(hostonly_mtu, public_mtu) }}
+{% end %}
 {% if sriov_interface is defined %}
 - type: sriov_pf
   name: {{ sriov_interface }}

--- a/playbooks/templates/standalone_parameters.yaml.j2
+++ b/playbooks/templates/standalone_parameters.yaml.j2
@@ -140,14 +140,14 @@ parameter_defaults:
   AdminPassword: {{ admin_password }}
 {% endif %}
 {% if rhsm_enabled %}
-{% if ntp_server is defined %}
-  NtpServer: {{ ntp_server }}
-{% endif %}
   ContainerImageRegistryCredentials:
     # assume first registry
     {{ registers.0.name | ansible.builtin.mandatory}}:
       {{ registers.0.username | ansible.builtin.mandatory | ansible.builtin.quote }}: {{ registers.0.password | ansible.builtin.mandatory | ansible.builtin.quote }}
   ContainerImageRegistryLogin: true
+{% endif %}
+{% if ntp_server is defined %}
+  NtpServer: {{ ntp_server }}
 {% endif %}
 {% if ssl_enabled %}
   AddVipsToEtcHosts: true

--- a/playbooks/vars/defaults.yaml
+++ b/playbooks/vars/defaults.yaml
@@ -270,3 +270,12 @@ public_mtu: "{{ ctlplane_mtu | int + 100 }}"
 # Usually people don't use RHSM when deploying from the internal RH network, but use
 # the puddles; so they'll get our internal NTP server.
 ntp_server: "{{ rhsm_enabled | ternary('0.pool.ntp.org', 'clock.redhat.com') }}"
+
+# Dummy interfaces may have max mtu = 0, which causes failure when os-net-config tries to apply
+# the specified mtu. This allows disabling setting mtu for dummy interfaces.
+enable_dummy_mtu: true
+
+# If external_fip_pool_start and external_fip_pool_end are not defined, network `external`
+# will not be created. `hostonly` can be used as the external network for the router when
+# running `prepare_stack_testconfig.yaml`
+external_network: external


### PR DESCRIPTION
This PR fixes following issues I found during deployment.

* os-net-config fails when the max_mtu of dummy interfaces is 0 .  Add `enable_dummy_mtu` to skip setting mtu for dummy interfaces.
* If `external_fip_pool_start` and `external_fip_pool_end` are not defined, network `external` will not be created. Running `make prepare_stack_testconfig` will fail when setting the gateway for the private router.  Add `external_network` to allow using `hostonly`.
* If `rhsm_enabled` is not true, `NtpServer` in `playbooks/templates/standalone_parameters.yaml.j2` will not be set, which results chrony sync failure during deployment in internal network. Move `NtpServer` out of `rhsm_enabled` check to allow setting internal ntp server. 